### PR TITLE
Feat/setup api

### DIFF
--- a/App.js
+++ b/App.js
@@ -14,6 +14,7 @@ export default function App() {
     console.log('--------------------------')
     console.log(result);
     console.log('--------------------------')
+    
   }
 
   return (
@@ -26,9 +27,9 @@ export default function App() {
         value={userInput}
       />
       <Button title='Get Weather' onPress={() => HandleSearchButton()}/>
-      {weeklyForecast.map((data) => {
+      {weeklyForecast.map((data) => (
         <Text>{data.date} - {data.tempMax} / {data.tempMin}</Text>
-      })}
+      ))}
     </View>
   );
 }

--- a/App.js
+++ b/App.js
@@ -1,11 +1,34 @@
+import { useState } from 'react'
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, Button, TextInput } from 'react-native';
+import { GetWeatherForecast } from './src/api/api';
 
 export default function App() {
+  const [userInput, setUserInput] = useState('');
+  const [weeklyForecast, setWeeklyForecast] = useState([]);
+
+  const HandleSearchButton = () => {
+    var result = GetWeatherForecast(userInput);
+    setWeeklyForecast(result);
+
+    console.log('--------------------------')
+    console.log(result);
+    console.log('--------------------------')
+  }
+
   return (
     <View style={styles.container}>
-      <Text>Rixun Weather App</Text>
+      <Text>{userInput}</Text>
       <StatusBar style="auto" />
+      <TextInput
+        style={styles.textInput}
+        onChangeText={setUserInput}
+        value={userInput}
+      />
+      <Button title='Get Weather' onPress={() => HandleSearchButton()}/>
+      {weeklyForecast.map((data) => {
+        <Text>{data.date} - {data.tempMax} / {data.tempMin}</Text>
+      })}
     </View>
   );
 }
@@ -15,6 +38,14 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#fff',
     alignItems: 'center',
-    justifyContent: 'center',
+    marginTop: 80,
+    // justifyContent: 'center',
   },
+  textInput: {
+    height: 40,
+    width: 350,
+    margin: 12,
+    borderWidth: 1,
+    padding: 10,
+  }
 });

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -13,17 +13,14 @@ const APICallDaily = async (long, lat) => {
   //var res = await fetch(`https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${long}&daily=temperature_2m_max,temperature_2m_min&timezone=Australia%2FSydney`);
   var res = await fetch(`https://api.open-meteo.com/v1/forecast?latitude=-33.87&longitude=151.21&&daily=temperature_2m_max,temperature_2m_min&timezone=Australia%2FSydney`);
   var resData = await res.json();
-  var tempArr = [];
 
   for (var i = 0; i < resData['daily']['time'].length; i++) {
     var dailyResult = {};
     dailyResult.date = resData['daily']['time'][i];
     dailyResult.tempMax = resData['daily']['temperature_2m_max'][i];
     dailyResult.tempMin = resData['daily']['temperature_2m_min'][i];
-    tempArr.push(dailyResult);
+    weeklyForecast.push(dailyResult);
   }
-
-  weeklyForecast.push(tempArr);
 }
   
 export function GetWeatherForecast(searchInput) {

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,45 @@
+import jsonData from './suburbs.json';
+var resTemp = '';
+var weeklyForecast = [];
+var searchBy = "suburb"; // make configurable later
+
+const APICall = async (long, lat) => {
+  var res = await fetch(`https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${long}&current_weather=true&hourly=temperature_2m,relativehumidity_2m,windspeed_10m`)
+  var resData = await res.json();
+  resTemp = resData['current_weather'].temperature;
+}
+
+const APICallDaily = async (long, lat) => {
+  //var res = await fetch(`https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${long}&daily=temperature_2m_max,temperature_2m_min&timezone=Australia%2FSydney`);
+  var res = await fetch(`https://api.open-meteo.com/v1/forecast?latitude=-33.87&longitude=151.21&&daily=temperature_2m_max,temperature_2m_min&timezone=Australia%2FSydney`);
+  var resData = await res.json();
+  var tempArr = [];
+
+  for (var i = 0; i < resData['daily']['time'].length; i++) {
+    var dailyResult = {};
+    dailyResult.date = resData['daily']['time'][i];
+    dailyResult.tempMax = resData['daily']['temperature_2m_max'][i];
+    dailyResult.tempMin = resData['daily']['temperature_2m_min'][i];
+    tempArr.push(dailyResult);
+  }
+
+  weeklyForecast.push(tempArr);
+}
+  
+export function GetWeatherForecast(searchInput) {
+  var searchForLatitude = '';
+  var searchForLongitude = '';
+
+  for (var i = 0; i < jsonData.data.length; i++) {
+    if (jsonData.data[i][searchBy] == searchInput) {
+      //searchResults = jsonData.data[i];
+      searchForLatitude = jsonData.data[i].lat;
+      searchForLongitude = jsonData.data[i].long;
+    }
+  }
+  
+  //APICall(searchForLongitude, searchForLatitude);
+  APICallDaily(searchForLongitude, searchForLatitude);
+
+  return weeklyForecast;
+}

--- a/src/api/suburbs.json
+++ b/src/api/suburbs.json
@@ -1,0 +1,9765 @@
+{
+	"data":
+	[
+		{
+			"suburb": "East Albury",
+			"postcode": 2640,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 246,
+			"lat": -36.09041,
+			"long": 146.93912,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lavington",
+			"postcode": 2641,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 207,
+			"lat": -36.02909,
+			"long": 146.93586,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glenroy",
+			"postcode": 2640,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 256,
+			"lat": -36.05258,
+			"long": 146.89876,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Albury",
+			"postcode": 2640,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 166,
+			"lat": -36.07352,
+			"long": 146.91573,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "North Albury",
+			"postcode": 2640,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 172,
+			"lat": -36.06059,
+			"long": 146.93743,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Table Top",
+			"postcode": 2640,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 192,
+			"lat": -35.93717,
+			"long": 147.02997,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Splitters Creek",
+			"postcode": 2640,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 260,
+			"lat": -36.05218,
+			"long": 146.84864,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "West Albury",
+			"postcode": 2640,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 177,
+			"lat": -36.07353,
+			"long": 146.88731,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Springdale Heights",
+			"postcode": 2641,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 301,
+			"lat": -36.02548,
+			"long": 146.95794,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Thurgoona",
+			"postcode": 2640,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 197,
+			"lat": -36.05481,
+			"long": 146.98849,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "South Albury",
+			"postcode": 2640,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 157,
+			"lat": -36.09831,
+			"long": 146.91415,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wirlinga",
+			"postcode": 2640,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 296,
+			"lat": -36.04811,
+			"long": 147.05654,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hamilton Valley",
+			"postcode": 2641,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 232,
+			"lat": -36.02472,
+			"long": 146.89686,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Jindera",
+			"postcode": 2642,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 238,
+			"lat": -35.95937,
+			"long": 146.88177,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Armidale",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1033,
+			"lat": -30.50195,
+			"long": 151.66739,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Boorolong",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1180,
+			"lat": -30.35699,
+			"long": 151.45893,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dumaresq",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1139,
+			"lat": -30.43302,
+			"long": 151.55409,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Duval",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1204,
+			"lat": -30.41398,
+			"long": 151.63446,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Donald Creek",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1122,
+			"lat": -30.42438,
+			"long": 151.76057,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Black Mountain",
+			"postcode": 2365,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1291,
+			"lat": -30.32917,
+			"long": 151.68914,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Aberfoyle",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1163,
+			"lat": -30.23695,
+			"long": 151.98519,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Thalgarrah",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1176,
+			"lat": -30.40553,
+			"long": 151.88916,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wollomombi",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1000,
+			"lat": -30.48225,
+			"long": 152.14401,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Jeogla",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 751,
+			"lat": -30.68695,
+			"long": 152.17593,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ebor",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1288,
+			"lat": -30.40543,
+			"long": 152.31573,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dangarsleigh",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1039,
+			"lat": -30.62796,
+			"long": 151.68227,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Metz",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 963,
+			"lat": -30.57975,
+			"long": 151.83313,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hillgrove",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 735,
+			"lat": -30.63081,
+			"long": 151.96912,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Castle Doyle",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 963,
+			"lat": -30.62825,
+			"long": 151.78619,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Enmore",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1122,
+			"lat": -30.72933,
+			"long": 151.84406,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lower Creek",
+			"postcode": 2440,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 530,
+			"lat": -30.66391,
+			"long": 152.28119,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Carrai",
+			"postcode": 2440,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 850,
+			"lat": -30.82848,
+			"long": 152.24865,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tilbuster",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1045,
+			"lat": -30.41649,
+			"long": 151.70075,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kellys Plains",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1012,
+			"lat": -30.5833,
+			"long": 151.62612,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wongwibinda",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1180,
+			"lat": -30.2705,
+			"long": 152.19963,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lyndhurst",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1269,
+			"lat": -30.35785,
+			"long": 152.05709,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Puddledock",
+			"postcode": 2350,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1138,
+			"lat": -30.38482,
+			"long": 151.75855,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Croydon Park",
+			"postcode": 2133,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 13,
+			"lat": -33.89732,
+			"long": 151.10289,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Croydon",
+			"postcode": 2132,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -33.88062,
+			"long": 151.1169,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ashfield",
+			"postcode": 2131,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 38,
+			"lat": -33.88947,
+			"long": 151.12753,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Haberfield",
+			"postcode": 2045,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 21,
+			"lat": -33.87968,
+			"long": 151.1391,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Summer Hill",
+			"postcode": 2130,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 29,
+			"lat": -33.89348,
+			"long": 151.1372,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hurlstone Park",
+			"postcode": 2193,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -33.91005,
+			"long": 151.12854,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ashbury",
+			"postcode": 2193,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 21,
+			"lat": -33.90113,
+			"long": 151.11777,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Guyong",
+			"postcode": 2798,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 877,
+			"lat": -33.39739,
+			"long": 149.26039,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Newington",
+			"postcode": 2127,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 19,
+			"lat": -33.83889,
+			"long": 151.05551,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lidcombe",
+			"postcode": 2141,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -33.86491,
+			"long": 151.04789,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Berala",
+			"postcode": 2141,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 34,
+			"lat": -33.87461,
+			"long": 151.03345,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Auburn",
+			"postcode": 2144,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 33,
+			"lat": -33.85787,
+			"long": 151.02827,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sydney Olympic Park",
+			"postcode": 2127,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 11,
+			"lat": -33.83935,
+			"long": 151.06654,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Silverwater",
+			"postcode": 2128,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 7,
+			"lat": -33.83414,
+			"long": 151.04521,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Regents Park",
+			"postcode": 2143,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 39,
+			"lat": -33.88245,
+			"long": 151.02748,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wentworth Point",
+			"postcode": 2127,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -33.82839,
+			"long": 151.07771,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rookwood",
+			"postcode": 2141,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 37,
+			"lat": -33.87488,
+			"long": 151.05634,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "East Ballina",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 18,
+			"lat": -28.85856,
+			"long": 153.58891,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tintenbar",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 6,
+			"lat": -28.79193,
+			"long": 153.53018,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cumbalum",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 42,
+			"lat": -28.81697,
+			"long": 153.53722,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Broken Head",
+			"postcode": 2481,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 23,
+			"lat": -28.73002,
+			"long": 153.59346,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lennox Head",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 19,
+			"lat": -28.79156,
+			"long": 153.58251,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Newrybar",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 51,
+			"lat": -28.72773,
+			"long": 153.54935,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Knockrow",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 75,
+			"lat": -28.76054,
+			"long": 153.54021,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Skennars Head",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 13,
+			"lat": -28.83301,
+			"long": 153.58983,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wardell",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1,
+			"lat": -28.96017,
+			"long": 153.45732,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "West Ballina",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -28.85657,
+			"long": 153.52284,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Alstonvale",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 96,
+			"lat": -28.7955,
+			"long": 153.44451,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "East Wardell",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1,
+			"lat": -28.96332,
+			"long": 153.4839,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wollongbar",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 165,
+			"lat": -28.82016,
+			"long": 153.40855,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bagotville",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 14,
+			"lat": -28.9771,
+			"long": 153.40871,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ballina",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -28.83481,
+			"long": 153.55796,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Fernleigh",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 106,
+			"lat": -28.76919,
+			"long": 153.48888,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Meerschaum Vale",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -28.92631,
+			"long": 153.41861,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Keith Hall",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 22,
+			"lat": -28.89346,
+			"long": 153.5458,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "South Ballina",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 7,
+			"lat": -28.885,
+			"long": 153.56988,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Teven",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 33,
+			"lat": -28.81447,
+			"long": 153.49145,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Alstonville",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 152,
+			"lat": -28.83869,
+			"long": 153.44743,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cabbage Tree Island",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -28.98013,
+			"long": 153.45672,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Goat Island",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -28.98862,
+			"long": 153.45729,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pimlico Island",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 2,
+			"lat": -28.91774,
+			"long": 153.49456,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pimlico",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 2,
+			"lat": -28.89426,
+			"long": 153.49903,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rous Mill",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 132,
+			"lat": -28.8798,
+			"long": 153.38181,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dalwood",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 142,
+			"lat": -28.89386,
+			"long": 153.41514,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Marom Creek",
+			"postcode": 2480,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 6,
+			"lat": -28.90867,
+			"long": 153.36512,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Patchs Beach",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -28.94696,
+			"long": 153.50893,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rous",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 183,
+			"lat": -28.86359,
+			"long": 153.40664,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lynwood",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 164,
+			"lat": -28.87076,
+			"long": 153.44272,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Uralba",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 6,
+			"lat": -28.87374,
+			"long": 153.4782,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Empire Vale",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -28.92253,
+			"long": 153.51995,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tuckombil",
+			"postcode": 2477,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 142,
+			"lat": -28.8128,
+			"long": 153.4678,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Brooklet",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 109,
+			"lat": -28.7464,
+			"long": 153.50417,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coolgardie",
+			"postcode": 2478,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 156,
+			"lat": -28.916,
+			"long": 153.46031,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "McLeans Ridges",
+			"postcode": 2480,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 148,
+			"lat": -28.79233,
+			"long": 153.39586,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Euston",
+			"postcode": 2737,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 71,
+			"lat": -34.37351,
+			"long": 142.83635,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Balranald",
+			"postcode": 2715,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 60,
+			"lat": -34.32979,
+			"long": 143.38926,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hatfield",
+			"postcode": 2715,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 78,
+			"lat": -33.72245,
+			"long": 143.70999,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Oxley",
+			"postcode": 2711,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 76,
+			"lat": -34.04068,
+			"long": 144.07173,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ivanhoe",
+			"postcode": 2878,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 95,
+			"lat": -32.70224,
+			"long": 144.18213,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mossgiel",
+			"postcode": 2878,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 94,
+			"lat": -33.28096,
+			"long": 144.56349,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Corrong",
+			"postcode": 2711,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 84,
+			"lat": -34.02416,
+			"long": 144.49898,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Arumpo",
+			"postcode": 2715,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 68,
+			"lat": -33.59205,
+			"long": 143.02266,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hornsby",
+			"postcode": 2077,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 187,
+			"lat": -33.69724,
+			"long": 151.10055,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Clare",
+			"postcode": 2711,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 82,
+			"lat": -33.46751,
+			"long": 143.97828,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kyalite",
+			"postcode": 2715,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 69,
+			"lat": -34.9038,
+			"long": 143.52329,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mungo",
+			"postcode": 2715,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 64,
+			"lat": -33.75375,
+			"long": 143.08284,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Booligal",
+			"postcode": 2711,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 89,
+			"lat": -33.7322,
+			"long": 144.68326,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Condell Park",
+			"postcode": 2200,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 30,
+			"lat": -33.92599,
+			"long": 151.00978,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bankstown",
+			"postcode": 2200,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 21,
+			"lat": -33.91991,
+			"long": 151.03125,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Punchbowl",
+			"postcode": 2196,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 22,
+			"lat": -33.92907,
+			"long": 151.05159,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Lewis",
+			"postcode": 2190,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 61,
+			"lat": -33.91572,
+			"long": 151.05024,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Greenacre",
+			"postcode": 2190,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 37,
+			"lat": -33.8989,
+			"long": 151.05729,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yagoona",
+			"postcode": 2199,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 44,
+			"lat": -33.90422,
+			"long": 151.02148,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Chullora",
+			"postcode": 2190,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 39,
+			"lat": -33.89266,
+			"long": 151.04829,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bonny Hills",
+			"postcode": 2445,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 19,
+			"lat": -31.57442,
+			"long": 152.81764,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Georges Hall",
+			"postcode": 2198,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 23,
+			"lat": -33.90761,
+			"long": 150.98902,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Villawood",
+			"postcode": 2163,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 23,
+			"lat": -33.88432,
+			"long": 150.98067,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bass Hill",
+			"postcode": 2197,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 40,
+			"lat": -33.90028,
+			"long": 150.99309,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Chester Hill",
+			"postcode": 2162,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 46,
+			"lat": -33.88004,
+			"long": 150.99733,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sefton",
+			"postcode": 2162,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 39,
+			"lat": -33.88742,
+			"long": 151.0104,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Revesby",
+			"postcode": 2212,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 14,
+			"lat": -33.94767,
+			"long": 151.01233,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lansdowne",
+			"postcode": 2163,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -33.89624,
+			"long": 150.97658,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Potts Hill",
+			"postcode": 2143,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 59,
+			"lat": -33.89271,
+			"long": 151.03275,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Birrong",
+			"postcode": 2143,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 36,
+			"lat": -33.89192,
+			"long": 151.02094,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bankstown Aerodrome",
+			"postcode": 2200,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 8,
+			"lat": -33.92329,
+			"long": 150.99027,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Milperra",
+			"postcode": 2214,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 15,
+			"lat": -33.94109,
+			"long": 150.98349,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "East Hills",
+			"postcode": 2213,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 9,
+			"lat": -33.96119,
+			"long": 150.98818,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Panania",
+			"postcode": 2213,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 18,
+			"lat": -33.95493,
+			"long": 150.99524,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Picnic Point",
+			"postcode": 2213,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 33,
+			"lat": -33.97301,
+			"long": 151.00632,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Revesby Heights",
+			"postcode": 2212,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 36,
+			"lat": -33.96919,
+			"long": 151.01822,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Padstow",
+			"postcode": 2211,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 17,
+			"lat": -33.95023,
+			"long": 151.03068,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Padstow Heights",
+			"postcode": 2211,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 51,
+			"lat": -33.97042,
+			"long": 151.03352,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eglinton",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 671,
+			"lat": -33.36736,
+			"long": 149.54308,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "West Bathurst",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 709,
+			"lat": -33.40794,
+			"long": 149.56176,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bathurst",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 677,
+			"lat": -33.41899,
+			"long": 149.57822,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "South Bathurst",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 675,
+			"lat": -33.4427,
+			"long": 149.57444,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kelso",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 689,
+			"lat": -33.4286,
+			"long": 149.62263,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Raglan",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 735,
+			"lat": -33.42069,
+			"long": 149.65113,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Panorama",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 795,
+			"lat": -33.45107,
+			"long": 149.55214,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mitchell",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 708,
+			"lat": -33.42617,
+			"long": 149.55775,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "White Rock",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 663,
+			"lat": -33.46169,
+			"long": 149.61692,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Windradyne",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 705,
+			"lat": -33.40579,
+			"long": 149.54454,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gormans Hill",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 700,
+			"lat": -33.46815,
+			"long": 149.59526,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Orton Park",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 669,
+			"lat": -33.46781,
+			"long": 149.57298,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Forest Grove",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 725,
+			"lat": -33.38908,
+			"long": 149.66106,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Llanarth",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 695,
+			"lat": -33.39785,
+			"long": 149.55099,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Abercrombie",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 658,
+			"lat": -33.39205,
+			"long": 149.55367,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Robin Hill",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 758,
+			"lat": -33.42392,
+			"long": 149.53175,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Laffing Waters",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 724,
+			"lat": -33.36741,
+			"long": 149.61966,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Georges Plains",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 748,
+			"lat": -33.53022,
+			"long": 149.4909,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wimbledon",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 843,
+			"lat": -33.53998,
+			"long": 149.43485,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wisemans Creek",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 759,
+			"lat": -33.63551,
+			"long": 149.71256,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Charlton",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 768,
+			"lat": -33.6726,
+			"long": 149.63848,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Curragh",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 617,
+			"lat": -33.95091,
+			"long": 149.20604,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Abercrombie River",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 733,
+			"lat": -33.91177,
+			"long": 149.33265,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Caloola",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 906,
+			"lat": -33.63911,
+			"long": 149.43494,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Copperhannia",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 778,
+			"lat": -33.87559,
+			"long": 149.21311,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Colo",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 886,
+			"lat": -33.77583,
+			"long": 149.26472,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Arkell",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 963,
+			"lat": -33.73572,
+			"long": 149.38154,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cow Flat",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 743,
+			"lat": -33.57423,
+			"long": 149.51235,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Fosters Valley",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 910,
+			"lat": -33.61641,
+			"long": 149.5403,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Trunkey Creek",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 924,
+			"lat": -33.80655,
+			"long": 149.34199,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Triangle Flat",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 995,
+			"lat": -33.78763,
+			"long": 149.44994,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Meadow Flat",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1017,
+			"lat": -33.44048,
+			"long": 149.92553,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Millah Murrah",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 643,
+			"lat": -33.1778,
+			"long": 149.60211,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wiagdon",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 679,
+			"lat": -33.21622,
+			"long": 149.66267,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Clear Creek",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 799,
+			"lat": -33.33365,
+			"long": 149.71685,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Upper Turon",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 720,
+			"lat": -33.13213,
+			"long": 149.77846,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sunny Corner",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1166,
+			"lat": -33.374,
+			"long": 149.87982,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yetholme",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1235,
+			"lat": -33.43259,
+			"long": 149.81415,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Locksley",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 843,
+			"lat": -33.51554,
+			"long": 149.79864,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Milkers Flat",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 639,
+			"lat": -33.28085,
+			"long": 149.39791,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sallys Flat",
+			"postcode": 2850,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 807,
+			"lat": -33.02976,
+			"long": 149.56818,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kirkconnell",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1142,
+			"lat": -33.42186,
+			"long": 149.8521,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gemalla",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1025,
+			"lat": -33.50167,
+			"long": 149.84233,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gowan",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 891,
+			"lat": -33.14962,
+			"long": 149.35098,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Freemantle",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 649,
+			"lat": -33.27954,
+			"long": 149.36488,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Killongbutta",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 659,
+			"lat": -33.18202,
+			"long": 149.42588,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bruinbun",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 770,
+			"lat": -33.11923,
+			"long": 149.47319,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Peel",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 708,
+			"lat": -33.30031,
+			"long": 149.65436,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Crudine",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 699,
+			"lat": -32.98189,
+			"long": 149.67504,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glanmire",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 778,
+			"lat": -33.42048,
+			"long": 149.70868,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Paling Yards",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 972,
+			"lat": -33.17999,
+			"long": 149.74452,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Napoleon Reef",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 787,
+			"lat": -33.39306,
+			"long": 149.74713,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tarana",
+			"postcode": 2787,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 784,
+			"lat": -33.54282,
+			"long": 149.8835,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wattle Flat",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 940,
+			"lat": -33.14822,
+			"long": 149.68001,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sofala",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 632,
+			"lat": -33.05221,
+			"long": 149.69533,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Walang",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 929,
+			"lat": -33.45191,
+			"long": 149.76801,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tambaroora",
+			"postcode": 2850,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 860,
+			"lat": -32.96504,
+			"long": 149.40327,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Duramana",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 772,
+			"lat": -33.25552,
+			"long": 149.54998,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Rankin",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 911,
+			"lat": -33.29542,
+			"long": 149.47777,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Turondale",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 738,
+			"lat": -33.1164,
+			"long": 149.59522,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Billywillinga",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 851,
+			"lat": -33.28651,
+			"long": 149.43743,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rock Forest",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 747,
+			"lat": -33.35538,
+			"long": 149.40076,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Watton",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 726,
+			"lat": -33.31249,
+			"long": 149.41692,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yarras",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 723,
+			"lat": -33.36586,
+			"long": 149.67356,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "The Rocks",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 862,
+			"lat": -33.43208,
+			"long": 149.42276,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bathampton",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 729,
+			"lat": -33.49192,
+			"long": 149.41364,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dunkeld",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 648,
+			"lat": -33.41056,
+			"long": 149.48096,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Vittoria",
+			"postcode": 2799,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 901,
+			"lat": -33.41713,
+			"long": 149.34886,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Fitzgeralds Valley",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 750,
+			"lat": -33.52397,
+			"long": 149.39364,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Fitzgeralds Mount",
+			"postcode": 2799,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 945,
+			"lat": -33.496,
+			"long": 149.37749,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "O'Connell",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 753,
+			"lat": -33.55661,
+			"long": 149.74675,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rockley Mount",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 806,
+			"lat": -33.55312,
+			"long": 149.55535,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Brewongle",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 721,
+			"lat": -33.4724,
+			"long": 149.69051,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "The Lagoon",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 722,
+			"lat": -33.54556,
+			"long": 149.62179,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bald Ridge",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 660,
+			"lat": -33.93829,
+			"long": 149.42276,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bella Vista",
+			"postcode": 2153,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 101,
+			"lat": -33.74234,
+			"long": 150.95464,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Baulkham Hills",
+			"postcode": 2153,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 93,
+			"lat": -33.74634,
+			"long": 150.98287,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Castle Hill",
+			"postcode": 2154,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 112,
+			"lat": -33.72933,
+			"long": 150.99777,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kellyville",
+			"postcode": 2155,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 78,
+			"lat": -33.69583,
+			"long": 150.95622,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "West Pennant Hills",
+			"postcode": 2125,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 109,
+			"lat": -33.74763,
+			"long": 151.03335,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Winston Hills",
+			"postcode": 2153,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 77,
+			"lat": -33.77692,
+			"long": 150.98008,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glenhaven",
+			"postcode": 2156,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 123,
+			"lat": -33.70276,
+			"long": 150.99604,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rouse Hill",
+			"postcode": 2155,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 45,
+			"lat": -33.67757,
+			"long": 150.91278,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Beaumont Hills",
+			"postcode": 2155,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 67,
+			"lat": -33.69788,
+			"long": 150.94161,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kenthurst",
+			"postcode": 2156,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 53,
+			"lat": -33.6385,
+			"long": 150.9735,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cattai",
+			"postcode": 2756,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -33.54239,
+			"long": 150.91777,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dural",
+			"postcode": 2158,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 219,
+			"lat": -33.68508,
+			"long": 151.04147,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wisemans Ferry",
+			"postcode": 2775,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -33.39544,
+			"long": 150.98047,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lower Portland",
+			"postcode": 2756,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 49,
+			"lat": -33.44193,
+			"long": 150.88137,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Maroota",
+			"postcode": 2756,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 134,
+			"lat": -33.45976,
+			"long": 150.97347,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sackville North",
+			"postcode": 2756,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 14,
+			"lat": -33.48685,
+			"long": 150.90163,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "South Maroota",
+			"postcode": 2756,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 108,
+			"lat": -33.50959,
+			"long": 150.95763,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glenorie",
+			"postcode": 2157,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 97,
+			"lat": -33.57079,
+			"long": 150.98602,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Maraylya",
+			"postcode": 2765,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 27,
+			"lat": -33.59439,
+			"long": 150.91597,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Middle Dural",
+			"postcode": 2158,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 143,
+			"lat": -33.63844,
+			"long": 151.01006,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Box Hill",
+			"postcode": 2765,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 40,
+			"lat": -33.64417,
+			"long": 150.89911,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nelson",
+			"postcode": 2765,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 65,
+			"lat": -33.64457,
+			"long": 150.92333,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Annangrove",
+			"postcode": 2156,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 83,
+			"lat": -33.65546,
+			"long": 150.95159,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "North Rocks",
+			"postcode": 2151,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 92,
+			"lat": -33.77572,
+			"long": 151.01474,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Oatlands",
+			"postcode": 2117,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 54,
+			"lat": -33.79508,
+			"long": 151.02527,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Carlingford",
+			"postcode": 2118,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 102,
+			"lat": -33.77523,
+			"long": 151.0454,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Northmead",
+			"postcode": 2152,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 49,
+			"lat": -33.78379,
+			"long": 150.99349,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "North Parramatta",
+			"postcode": 2151,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 56,
+			"lat": -33.79411,
+			"long": 151.0117,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wonboyn North",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 147,
+			"lat": -37.19869,
+			"long": 149.90497,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mumbulla Mountain",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 242,
+			"lat": -36.53343,
+			"long": 149.88866,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Angledale",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 82,
+			"lat": -36.63357,
+			"long": 149.8683,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Frogs Hollow",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 87,
+			"lat": -36.76362,
+			"long": 149.81617,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kanoona",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 89,
+			"lat": -36.74811,
+			"long": 149.77545,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Devils Hole",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 370,
+			"lat": -36.87327,
+			"long": 149.64948,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Morans Crossing",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 126,
+			"lat": -36.66822,
+			"long": 149.65451,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yellow Pinch",
+			"postcode": 2548,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 138,
+			"lat": -36.85823,
+			"long": 149.83571,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bermagui",
+			"postcode": 2546,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 45,
+			"lat": -36.42695,
+			"long": 150.03923,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Barragga Bay",
+			"postcode": 2546,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 43,
+			"lat": -36.50366,
+			"long": 150.05204,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cuttagee",
+			"postcode": 2546,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1,
+			"lat": -36.48445,
+			"long": 150.03813,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Green Cape",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 40,
+			"lat": -37.21212,
+			"long": 150.00351,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tinpot",
+			"postcode": 2546,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 243,
+			"lat": -36.24472,
+			"long": 149.89143,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tarraganda",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -36.6782,
+			"long": 149.86563,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tanja",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 93,
+			"lat": -36.62516,
+			"long": 149.96428,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Edrom",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 53,
+			"lat": -37.13357,
+			"long": 149.95858,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wolumla",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 123,
+			"lat": -36.81613,
+			"long": 149.81469,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Quaama",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 170,
+			"lat": -36.46639,
+			"long": 149.89039,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pambula",
+			"postcode": 2549,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 9,
+			"lat": -36.92999,
+			"long": 149.87665,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eden",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 173,
+			"lat": -37.01948,
+			"long": 149.89459,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bega",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 37,
+			"lat": -36.6858,
+			"long": 149.84245,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Merimbula",
+			"postcode": 2548,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 0,
+			"lat": -36.89614,
+			"long": 149.90424,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pambula Beach",
+			"postcode": 2549,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 50,
+			"lat": -36.94474,
+			"long": 149.8991,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Candelo",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 167,
+			"lat": -36.78368,
+			"long": 149.66763,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wyndham",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 268,
+			"lat": -36.92217,
+			"long": 149.63377,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kingswood",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 42,
+			"lat": -36.74426,
+			"long": 149.82036,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "South Pambula",
+			"postcode": 2549,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 49,
+			"lat": -36.94869,
+			"long": 149.85359,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mirador",
+			"postcode": 2548,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 56,
+			"lat": -36.87677,
+			"long": 149.91989,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Berrambool",
+			"postcode": 2548,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 12,
+			"lat": -36.88087,
+			"long": 149.91027,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tathra",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 83,
+			"lat": -36.73733,
+			"long": 149.96654,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wallaga Lake",
+			"postcode": 2546,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 0,
+			"lat": -36.36991,
+			"long": 150.05482,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wapengo",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 69,
+			"lat": -36.58473,
+			"long": 149.96608,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wallagoot",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 35,
+			"lat": -36.76604,
+			"long": 149.92121,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Boydtown",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 12,
+			"lat": -37.10498,
+			"long": 149.87917,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kalaru",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 40,
+			"lat": -36.73111,
+			"long": 149.92941,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nungatta",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 406,
+			"lat": -37.20577,
+			"long": 149.41354,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nungatta South",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 321,
+			"lat": -37.27892,
+			"long": 149.45293,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Chinnock",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 128,
+			"lat": -36.69548,
+			"long": 149.93088,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nelson",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 88,
+			"lat": -36.66695,
+			"long": 149.957,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bemboka",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 194,
+			"lat": -36.61579,
+			"long": 149.5671,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Millingandi",
+			"postcode": 2549,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 24,
+			"lat": -36.88276,
+			"long": 149.85648,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nullica",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 288,
+			"lat": -37.05542,
+			"long": 149.77363,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Steeple Flat",
+			"postcode": 2631,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1162,
+			"lat": -36.57936,
+			"long": 149.37757,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Darragh",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 681,
+			"lat": -36.84696,
+			"long": 149.57767,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "New Buildings",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 201,
+			"lat": -36.96069,
+			"long": 149.55961,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kiah",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 36,
+			"lat": -37.15396,
+			"long": 149.83619,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Greendale",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 124,
+			"lat": -36.58179,
+			"long": 149.86683,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Numbugga",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 142,
+			"lat": -36.62236,
+			"long": 149.7105,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Brogo",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 290,
+			"lat": -36.47625,
+			"long": 149.69,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tantawangalo",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 426,
+			"lat": -36.74382,
+			"long": 149.57015,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Burragate",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 249,
+			"lat": -37.0024,
+			"long": 149.64101,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "South Wolumla",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 269,
+			"lat": -36.85717,
+			"long": 149.7657,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Towamba",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 56,
+			"lat": -37.10727,
+			"long": 149.71173,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mogilla",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 275,
+			"lat": -36.70807,
+			"long": 149.5615,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yowrie",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 234,
+			"lat": -36.3057,
+			"long": 149.73565,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lochiel",
+			"postcode": 2549,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 102,
+			"lat": -36.94665,
+			"long": 149.78377,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Verona",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 248,
+			"lat": -36.44744,
+			"long": 149.80887,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nethercote",
+			"postcode": 2549,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 217,
+			"lat": -37.02572,
+			"long": 149.7945,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Buckajo",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 239,
+			"lat": -36.69187,
+			"long": 149.75555,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coolagolite",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 95,
+			"lat": -36.44001,
+			"long": 149.97133,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tura Beach",
+			"postcode": 2548,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 65,
+			"lat": -36.85986,
+			"long": 149.92501,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cobargo",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 92,
+			"lat": -36.39471,
+			"long": 149.88836,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dignams Creek",
+			"postcode": 2546,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 71,
+			"lat": -36.31507,
+			"long": 149.97006,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wandella",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 194,
+			"lat": -36.30868,
+			"long": 149.87001,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Stony Creek",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 200,
+			"lat": -36.61731,
+			"long": 149.80198,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Toothdale",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 120,
+			"lat": -36.78034,
+			"long": 149.75126,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pericoe",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 348,
+			"lat": -37.05439,
+			"long": 149.58422,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Myrtle Mountain",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 455,
+			"lat": -36.85567,
+			"long": 149.68366,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rocky Hall",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 210,
+			"lat": -36.92254,
+			"long": 149.50501,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Broadwater",
+			"postcode": 2549,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 0,
+			"lat": -36.97201,
+			"long": 149.89187,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Murrah",
+			"postcode": 2546,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 99,
+			"lat": -36.51768,
+			"long": 149.98489,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bournda",
+			"postcode": 2548,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 139,
+			"lat": -36.8114,
+			"long": 149.88941,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wonboyn",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 10,
+			"lat": -37.25588,
+			"long": 149.93485,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Greigs Flat",
+			"postcode": 2549,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 51,
+			"lat": -36.97379,
+			"long": 149.85238,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Black Range",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 200,
+			"lat": -36.73385,
+			"long": 149.84332,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Narrabarba",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 199,
+			"lat": -37.22079,
+			"long": 149.77249,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kameruka",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 106,
+			"lat": -36.71649,
+			"long": 149.69874,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bald Hills",
+			"postcode": 2549,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 112,
+			"lat": -36.91032,
+			"long": 149.84467,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yankees Creek",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1005,
+			"lat": -36.48819,
+			"long": 149.54501,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coolangubra",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 721,
+			"lat": -37.00389,
+			"long": 149.4556,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Jellat Jellat",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 12,
+			"lat": -36.72389,
+			"long": 149.88184,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wadbilliga",
+			"postcode": 2546,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 433,
+			"lat": -36.24983,
+			"long": 149.62322,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nadgee",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 352,
+			"lat": -37.3682,
+			"long": 149.84324,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Timbillica",
+			"postcode": 2551,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 107,
+			"lat": -37.32308,
+			"long": 149.73612,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wog Wog",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 446,
+			"lat": -37.07439,
+			"long": 149.45165,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cathcart",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 616,
+			"lat": -36.86575,
+			"long": 149.42599,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Reedy Swamp",
+			"postcode": 2550,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 59,
+			"lat": -36.69954,
+			"long": 149.90468,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bellingen",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -30.45402,
+			"long": 152.89238,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Urunga",
+			"postcode": 2455,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 19,
+			"lat": -30.51851,
+			"long": 152.98859,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mylestom",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 5,
+			"lat": -30.47587,
+			"long": 153.04029,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Megan",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 720,
+			"lat": -30.2997,
+			"long": 152.77554,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Deer Vale",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1180,
+			"lat": -30.34938,
+			"long": 152.53928,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cascade",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 673,
+			"lat": -30.23112,
+			"long": 152.77418,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kalang",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 311,
+			"lat": -30.49504,
+			"long": 152.71045,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Spicketts Creek",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 36,
+			"lat": -30.53472,
+			"long": 152.86273,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Valla",
+			"postcode": 2448,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 22,
+			"lat": -30.58354,
+			"long": 152.9584,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bostobrick",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 771,
+			"lat": -30.27688,
+			"long": 152.6016,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Darkwood",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 165,
+			"lat": -30.429,
+			"long": 152.63799,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Brierfield",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 15,
+			"lat": -30.51557,
+			"long": 152.91364,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tallowwood Ridge",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 731,
+			"lat": -30.25599,
+			"long": 152.72441,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Thora",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 111,
+			"lat": -30.43682,
+			"long": 152.77836,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gleniffer",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 50,
+			"lat": -30.38163,
+			"long": 152.88327,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Never Never",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 844,
+			"lat": -30.35723,
+			"long": 152.82993,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Valery",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 30,
+			"lat": -30.38914,
+			"long": 152.95808,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Fernmount",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 44,
+			"lat": -30.4767,
+			"long": 152.94445,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Brinerville",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 488,
+			"lat": -30.47236,
+			"long": 152.50813,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dorrigo",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 745,
+			"lat": -30.32769,
+			"long": 152.69235,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Repton",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 43,
+			"lat": -30.44154,
+			"long": 153.03532,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kennaicle Creek",
+			"postcode": 2449,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 151,
+			"lat": -30.5289,
+			"long": 152.8177,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Fernbrook",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 776,
+			"lat": -30.34349,
+			"long": 152.61228,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dorrigo Mountain",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 758,
+			"lat": -30.3706,
+			"long": 152.72224,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bielsdown Hills",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 789,
+			"lat": -30.37186,
+			"long": 152.6712,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "North Dorrigo",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 739,
+			"lat": -30.26491,
+			"long": 152.68073,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Raleigh",
+			"postcode": 2454,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -30.45824,
+			"long": 152.99413,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tocumwal",
+			"postcode": 2714,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 107,
+			"lat": -35.79102,
+			"long": 145.5083,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Finley",
+			"postcode": 2713,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 110,
+			"lat": -35.59323,
+			"long": 145.57945,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Berrigan",
+			"postcode": 2712,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 121,
+			"lat": -35.65031,
+			"long": 145.82832,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Barooga",
+			"postcode": 3644,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 118,
+			"lat": -35.90962,
+			"long": 145.69879,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Boomanoomana",
+			"postcode": 2712,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 118,
+			"lat": -35.88667,
+			"long": 145.8499,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Savernake",
+			"postcode": 2646,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 130,
+			"lat": -35.73554,
+			"long": 146.02409,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lalalty",
+			"postcode": 3644,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 116,
+			"lat": -35.80535,
+			"long": 145.71776,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mulwala",
+			"postcode": 2647,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 127,
+			"lat": -35.91969,
+			"long": 146.05748,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dean Park",
+			"postcode": 2761,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 39,
+			"lat": -33.73536,
+			"long": 150.8596,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Riverstone",
+			"postcode": 2765,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -33.66886,
+			"long": 150.85969,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Quakers Hill",
+			"postcode": 2763,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 40,
+			"lat": -33.72826,
+			"long": 150.88995,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Marayong",
+			"postcode": 2148,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 39,
+			"lat": -33.74925,
+			"long": 150.89081,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kings Park",
+			"postcode": 2148,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 57,
+			"lat": -33.7437,
+			"long": 150.9059,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kings Langley",
+			"postcode": 2147,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 81,
+			"lat": -33.75075,
+			"long": 150.93583,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glenwood",
+			"postcode": 2768,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 84,
+			"lat": -33.73755,
+			"long": 150.93545,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Colebee",
+			"postcode": 2761,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 38,
+			"lat": -33.72449,
+			"long": 150.85843,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Marsden Park",
+			"postcode": 2765,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 36,
+			"lat": -33.69979,
+			"long": 150.81845,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Shanes Park",
+			"postcode": 2747,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 32,
+			"lat": -33.70747,
+			"long": 150.79135,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Acacia Gardens",
+			"postcode": 2763,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 88,
+			"lat": -33.73411,
+			"long": 150.91377,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Parklea",
+			"postcode": 2768,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 81,
+			"lat": -33.72521,
+			"long": 150.91722,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Stanhope Gardens",
+			"postcode": 2768,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 64,
+			"lat": -33.71551,
+			"long": 150.92733,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Schofields",
+			"postcode": 2762,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 29,
+			"lat": -33.70583,
+			"long": 150.8735,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kellyville Ridge",
+			"postcode": 2155,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 72,
+			"lat": -33.70376,
+			"long": 150.92052,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Fairy Meadow",
+			"postcode": 2519,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 9,
+			"lat": -34.39689,
+			"long": 150.8957,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Balgownie",
+			"postcode": 2519,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 43,
+			"lat": -34.387,
+			"long": 150.8713,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Towradgi",
+			"postcode": 2518,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 11,
+			"lat": -34.38413,
+			"long": 150.90547,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "North Wollongong",
+			"postcode": 2500,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 6,
+			"lat": -34.40566,
+			"long": 150.89446,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "East Corrimal",
+			"postcode": 2518,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 10,
+			"lat": -34.37748,
+			"long": 150.91219,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wollongong",
+			"postcode": 2500,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 11,
+			"lat": -34.42826,
+			"long": 150.89296,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Keira",
+			"postcode": 2500,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 380,
+			"lat": -34.39723,
+			"long": 150.84944,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "West Wollongong",
+			"postcode": 2500,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 35,
+			"lat": -34.42572,
+			"long": 150.86768,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mangerton",
+			"postcode": 2500,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 61,
+			"lat": -34.4327,
+			"long": 150.87315,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coniston",
+			"postcode": 2500,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 44,
+			"lat": -34.43747,
+			"long": 150.88194,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Saint Thomas",
+			"postcode": 2500,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 47,
+			"lat": -34.44037,
+			"long": 150.87166,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Port Kembla",
+			"postcode": 2505,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 0,
+			"lat": -34.47109,
+			"long": 150.91352,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Doonside",
+			"postcode": 2767,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 44,
+			"lat": -33.76242,
+			"long": 150.87007,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Woodcroft",
+			"postcode": 2767,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 38,
+			"lat": -33.75523,
+			"long": 150.88065,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Blacktown",
+			"postcode": 2148,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 72,
+			"lat": -33.77655,
+			"long": 150.90338,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Prospect",
+			"postcode": 2148,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 57,
+			"lat": -33.81244,
+			"long": 150.90067,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Seven Hills",
+			"postcode": 2147,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 38,
+			"lat": -33.77743,
+			"long": 150.94272,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lalor Park",
+			"postcode": 2147,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 77,
+			"lat": -33.76065,
+			"long": 150.93136,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Toongabbie",
+			"postcode": 2146,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 39,
+			"lat": -33.79196,
+			"long": 150.9468,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Huntingwood",
+			"postcode": 2148,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 60,
+			"lat": -33.79733,
+			"long": 150.88345,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Arndell Park",
+			"postcode": 2148,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 56,
+			"lat": -33.79031,
+			"long": 150.88447,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eastern Creek",
+			"postcode": 2766,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 63,
+			"lat": -33.79734,
+			"long": 150.84976,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tregear",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 48,
+			"lat": -33.74517,
+			"long": 150.79271,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lethbridge Park",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 45,
+			"lat": -33.73806,
+			"long": 150.80064,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Shalvey",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 46,
+			"lat": -33.72788,
+			"long": 150.80677,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Whalan",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 37,
+			"lat": -33.75572,
+			"long": 150.80361,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Druitt",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 48,
+			"lat": -33.76791,
+			"long": 150.8136,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Blackett",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 50,
+			"lat": -33.73837,
+			"long": 150.81532,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dharruk",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 50,
+			"lat": -33.74965,
+			"long": 150.81483,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hebersham",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 60,
+			"lat": -33.74575,
+			"long": 150.82394,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Minchinbury",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 70,
+			"lat": -33.78664,
+			"long": 150.82899,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rooty Hill",
+			"postcode": 2766,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 43,
+			"lat": -33.77213,
+			"long": 150.845,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hassall Grove",
+			"postcode": 2761,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 44,
+			"lat": -33.73175,
+			"long": 150.83793,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glendenning",
+			"postcode": 2761,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 32,
+			"lat": -33.74778,
+			"long": 150.8557,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Emerton",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 50,
+			"lat": -33.7429,
+			"long": 150.80586,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bidwill",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 57,
+			"lat": -33.73005,
+			"long": 150.82062,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Willmot",
+			"postcode": 2770,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 40,
+			"lat": -33.72491,
+			"long": 150.79165,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Oakhurst",
+			"postcode": 2761,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 41,
+			"lat": -33.73724,
+			"long": 150.83862,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Plumpton",
+			"postcode": 2761,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 58,
+			"lat": -33.75211,
+			"long": 150.83639,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bungarribee",
+			"postcode": 2767,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 36,
+			"lat": -33.77976,
+			"long": 150.86393,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ropes Crossing",
+			"postcode": 2760,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 35,
+			"lat": -33.72757,
+			"long": 150.77848,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Naradhan",
+			"postcode": 2669,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 205,
+			"lat": -33.65613,
+			"long": 146.34992,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Weethalle",
+			"postcode": 2669,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 255,
+			"lat": -33.86293,
+			"long": 146.58443,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ungarie",
+			"postcode": 2669,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 241,
+			"lat": -33.58555,
+			"long": 146.91685,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "West Wyalong",
+			"postcode": 2671,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 305,
+			"lat": -33.87275,
+			"long": 147.11118,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wyalong",
+			"postcode": 2671,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 235,
+			"lat": -33.90311,
+			"long": 147.30345,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Girral",
+			"postcode": 2669,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 230,
+			"lat": -33.66512,
+			"long": 147.14846,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Back Creek",
+			"postcode": 2671,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 212,
+			"lat": -33.84678,
+			"long": 147.45639,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Barmedman",
+			"postcode": 2668,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 228,
+			"lat": -34.12202,
+			"long": 147.42794,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Barellan",
+			"postcode": 2665,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 161,
+			"lat": -34.19626,
+			"long": 146.60744,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kikoira",
+			"postcode": 2669,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 256,
+			"lat": -33.6666,
+			"long": 146.6636,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Beckom",
+			"postcode": 2665,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 219,
+			"lat": -34.28041,
+			"long": 147.00069,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mirrool",
+			"postcode": 2665,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 245,
+			"lat": -34.23017,
+			"long": 147.06294,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ariah Park",
+			"postcode": 2665,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 243,
+			"lat": -34.30527,
+			"long": 147.2019,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Alleena",
+			"postcode": 2671,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 277,
+			"lat": -34.09228,
+			"long": 147.13518,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "North Yalgogrin",
+			"postcode": 2671,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 335,
+			"lat": -33.82292,
+			"long": 146.84745,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tallimba",
+			"postcode": 2669,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 214,
+			"lat": -34.0492,
+			"long": 146.8819,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lake Cowal",
+			"postcode": 2671,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 224,
+			"lat": -33.66111,
+			"long": 147.37522,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bland",
+			"postcode": 2721,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 225,
+			"lat": -34.02509,
+			"long": 147.63048,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Quandialla",
+			"postcode": 2721,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 246,
+			"lat": -34.01933,
+			"long": 147.78266,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Morangarell",
+			"postcode": 2666,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 232,
+			"lat": -34.17389,
+			"long": 147.7163,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rankins Springs",
+			"postcode": 2669,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 216,
+			"lat": -33.784,
+			"long": 146.16148,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ardlethan",
+			"postcode": 2665,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 289,
+			"lat": -34.33458,
+			"long": 146.84248,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kamarah",
+			"postcode": 2665,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 188,
+			"lat": -34.3592,
+			"long": 146.75343,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Blayney",
+			"postcode": 2799,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 870,
+			"lat": -33.53741,
+			"long": 149.25456,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Errowanbang",
+			"postcode": 2791,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 680,
+			"lat": -33.53048,
+			"long": 149.03722,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Carcoar",
+			"postcode": 2791,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 756,
+			"lat": -33.61898,
+			"long": 149.13598,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Newbridge",
+			"postcode": 2795,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 887,
+			"lat": -33.58241,
+			"long": 149.373,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Forest Reefs",
+			"postcode": 2798,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 926,
+			"lat": -33.46567,
+			"long": 149.07316,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Browns Creek",
+			"postcode": 2799,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 876,
+			"lat": -33.53635,
+			"long": 149.14311,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Millthorpe",
+			"postcode": 2798,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 950,
+			"lat": -33.45554,
+			"long": 149.19474,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kings Plains",
+			"postcode": 2799,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 960,
+			"lat": -33.48984,
+			"long": 149.32401,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tallwood",
+			"postcode": 2798,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 920,
+			"lat": -33.50343,
+			"long": 149.12112,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Garland",
+			"postcode": 2797,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 755,
+			"lat": -33.75886,
+			"long": 149.03426,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Neville",
+			"postcode": 2799,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 843,
+			"lat": -33.74508,
+			"long": 149.2033,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Barry",
+			"postcode": 2799,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 910,
+			"lat": -33.64883,
+			"long": 149.27212,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mandurama",
+			"postcode": 2792,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 648,
+			"lat": -33.65929,
+			"long": 148.99372,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Burnt Yards",
+			"postcode": 2792,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 707,
+			"lat": -33.59022,
+			"long": 149.02452,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Panuara",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 642,
+			"lat": -33.51918,
+			"long": 148.928,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Blackheath",
+			"postcode": 2785,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1069,
+			"lat": -33.63908,
+			"long": 150.28442,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Katoomba",
+			"postcode": 2780,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1031,
+			"lat": -33.7057,
+			"long": 150.29458,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Blue Mountains National Park",
+			"postcode": 2780,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 275,
+			"lat": -33.83578,
+			"long": 150.32886,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Leura",
+			"postcode": 2780,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 938,
+			"lat": -33.70979,
+			"long": 150.33888,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wentworth Falls",
+			"postcode": 2782,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 839,
+			"lat": -33.72838,
+			"long": 150.3799,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lawson",
+			"postcode": 2783,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 727,
+			"lat": -33.71817,
+			"long": 150.4343,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hazelbrook",
+			"postcode": 2779,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 658,
+			"lat": -33.72807,
+			"long": 150.45754,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Faulconbridge",
+			"postcode": 2776,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 405,
+			"lat": -33.68513,
+			"long": 150.55384,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Springwood",
+			"postcode": 2777,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 370,
+			"lat": -33.69209,
+			"long": 150.57478,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Winmalee",
+			"postcode": 2777,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 263,
+			"lat": -33.67971,
+			"long": 150.61119,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Blaxland",
+			"postcode": 2774,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 237,
+			"lat": -33.74507,
+			"long": 150.61818,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glenbrook",
+			"postcode": 2773,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 199,
+			"lat": -33.76592,
+			"long": 150.62573,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Riverview",
+			"postcode": 2774,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 238,
+			"lat": -33.72773,
+			"long": 150.63789,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lapstone",
+			"postcode": 2773,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 178,
+			"lat": -33.77461,
+			"long": 150.63551,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yellow Rock",
+			"postcode": 2777,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 249,
+			"lat": -33.69332,
+			"long": 150.62904,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Medlow Bath",
+			"postcode": 2780,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1023,
+			"lat": -33.67971,
+			"long": 150.28985,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bullaburra",
+			"postcode": 2784,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 728,
+			"lat": -33.72779,
+			"long": 150.41952,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Woodford",
+			"postcode": 2778,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 578,
+			"lat": -33.73781,
+			"long": 150.47911,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Linden",
+			"postcode": 2778,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 553,
+			"lat": -33.71095,
+			"long": 150.49622,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Valley Heights",
+			"postcode": 2777,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 320,
+			"lat": -33.71038,
+			"long": 150.58383,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Warrimoo",
+			"postcode": 2774,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 210,
+			"lat": -33.7239,
+			"long": 150.61735,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bell",
+			"postcode": 2786,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 943,
+			"lat": -33.50034,
+			"long": 150.3026,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Berambing",
+			"postcode": 2758,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 711,
+			"lat": -33.53268,
+			"long": 150.44882,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Irvine",
+			"postcode": 2786,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 891,
+			"lat": -33.4798,
+			"long": 150.45478,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Victoria",
+			"postcode": 2786,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1018,
+			"lat": -33.57768,
+			"long": 150.24047,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Megalong Valley",
+			"postcode": 2785,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 553,
+			"lat": -33.72707,
+			"long": 150.22223,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Wilson",
+			"postcode": 2786,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 976,
+			"lat": -33.50403,
+			"long": 150.39359,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hawkesbury Heights",
+			"postcode": 2777,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 224,
+			"lat": -33.67019,
+			"long": 150.6452,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sun Valley",
+			"postcode": 2777,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 198,
+			"lat": -33.70782,
+			"long": 150.59796,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Tomah",
+			"postcode": 2758,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 965,
+			"lat": -33.5426,
+			"long": 150.42271,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hermidale",
+			"postcode": 2831,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 235,
+			"lat": -31.63132,
+			"long": 146.64526,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bobadah",
+			"postcode": 2877,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 379,
+			"lat": -32.28135,
+			"long": 146.6977,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pangee",
+			"postcode": 2825,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 235,
+			"lat": -32.00007,
+			"long": 146.79833,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Five Ways",
+			"postcode": 2873,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 226,
+			"lat": -32.16554,
+			"long": 146.96635,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Miandetta",
+			"postcode": 2825,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 190,
+			"lat": -31.5883,
+			"long": 146.91135,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nyngan",
+			"postcode": 2825,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 172,
+			"lat": -31.5438,
+			"long": 147.1529,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Honeybugle",
+			"postcode": 2825,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 206,
+			"lat": -31.83848,
+			"long": 146.85814,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coolabah",
+			"postcode": 2831,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 209,
+			"lat": -30.99969,
+			"long": 146.68886,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Girilambone",
+			"postcode": 2831,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 215,
+			"lat": -31.22967,
+			"long": 146.81566,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Canonba",
+			"postcode": 2825,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 164,
+			"lat": -31.31343,
+			"long": 147.43996,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Babinda",
+			"postcode": 2825,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 315,
+			"lat": -31.92247,
+			"long": 146.52159,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "The Marra",
+			"postcode": 2831,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 146,
+			"lat": -30.81053,
+			"long": 147.23112,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Byrock",
+			"postcode": 2831,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 151,
+			"lat": -30.50387,
+			"long": 146.36346,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Murrawombie",
+			"postcode": 2825,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 160,
+			"lat": -31.17668,
+			"long": 147.24824,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Buddabadah",
+			"postcode": 2825,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 182,
+			"lat": -31.94242,
+			"long": 147.16985,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mulla",
+			"postcode": 2825,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 184,
+			"lat": -31.82232,
+			"long": 147.36441,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Canbelego",
+			"postcode": 2835,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 288,
+			"lat": -31.51903,
+			"long": 146.25005,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bungarby",
+			"postcode": 2630,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 823,
+			"lat": -36.68774,
+			"long": 149.0459,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lords Hill",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 780,
+			"lat": -36.96786,
+			"long": 149.16684,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bombala",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 757,
+			"lat": -36.88991,
+			"long": 149.24766,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Craigie",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 766,
+			"lat": -37.08843,
+			"long": 149.05602,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mila",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 768,
+			"lat": -37.06043,
+			"long": 149.16222,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Palarang",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 766,
+			"lat": -36.82681,
+			"long": 149.13307,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gunningrah",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 777,
+			"lat": -36.74408,
+			"long": 149.15904,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Cooper",
+			"postcode": 2631,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 963,
+			"lat": -36.65367,
+			"long": 149.20122,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tombong",
+			"postcode": 2633,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 761,
+			"lat": -36.89847,
+			"long": 148.93199,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bondi Forest",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 907,
+			"lat": -37.15203,
+			"long": 149.19066,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bukalong",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 803,
+			"lat": -36.79952,
+			"long": 149.20878,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cambalong",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 664,
+			"lat": -36.89966,
+			"long": 149.11,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Holts Flat",
+			"postcode": 2631,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1097,
+			"lat": -36.61625,
+			"long": 149.2641,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Boco",
+			"postcode": 2631,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 978,
+			"lat": -36.61465,
+			"long": 149.16261,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Jincumbilly",
+			"postcode": 2631,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 803,
+			"lat": -36.7118,
+			"long": 149.22817,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glen Allen",
+			"postcode": 2631,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 930,
+			"lat": -36.69806,
+			"long": 149.37729,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Creewah",
+			"postcode": 2631,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 779,
+			"lat": -36.75749,
+			"long": 149.37838,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Paddys Flat",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 789,
+			"lat": -37.03632,
+			"long": 149.32845,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Byadbo Wilderness",
+			"postcode": 2628,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 718,
+			"lat": -36.8264,
+			"long": 148.62016,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Corrowong",
+			"postcode": 2633,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 771,
+			"lat": -36.90774,
+			"long": 148.77911,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Delegate",
+			"postcode": 2633,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 766,
+			"lat": -37.03792,
+			"long": 148.90325,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bibbenluke",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 734,
+			"lat": -36.80692,
+			"long": 149.3071,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ando",
+			"postcode": 2631,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 901,
+			"lat": -36.72595,
+			"long": 149.29417,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rockton",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 415,
+			"lat": -37.17662,
+			"long": 149.32029,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rosemeath",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 788,
+			"lat": -36.97173,
+			"long": 149.27022,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coolumbooka",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 826,
+			"lat": -36.91991,
+			"long": 149.33287,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Quidong",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 681,
+			"lat": -36.94722,
+			"long": 149.03899,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Merriangaah",
+			"postcode": 2632,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 764,
+			"lat": -36.84979,
+			"long": 149.01187,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Boorowa",
+			"postcode": 2586,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 533,
+			"lat": -34.36158,
+			"long": 148.74651,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wyangala",
+			"postcode": 2808,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 380,
+			"lat": -33.98038,
+			"long": 148.94794,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Reids Flat",
+			"postcode": 2586,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 453,
+			"lat": -34.12631,
+			"long": 148.99069,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Collins",
+			"postcode": 2794,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 373,
+			"lat": -34.02507,
+			"long": 148.78345,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rugby",
+			"postcode": 2583,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 553,
+			"lat": -34.39496,
+			"long": 149.01415,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rye Park",
+			"postcode": 2586,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 545,
+			"lat": -34.53479,
+			"long": 148.91915,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hovells Creek",
+			"postcode": 2794,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 441,
+			"lat": -34.05814,
+			"long": 148.86365,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Frogmore",
+			"postcode": 2586,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 500,
+			"lat": -34.24284,
+			"long": 148.87683,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Taylors Flat",
+			"postcode": 2586,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 461,
+			"lat": -34.2759,
+			"long": 149.01768,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Godfreys Creek",
+			"postcode": 2586,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 440,
+			"lat": -34.19685,
+			"long": 148.71591,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mascot",
+			"postcode": 2020,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -33.9466,
+			"long": 151.18371,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Botany",
+			"postcode": 2019,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 6,
+			"lat": -33.94907,
+			"long": 151.19881,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rosebery",
+			"postcode": 2018,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 18,
+			"lat": -33.91857,
+			"long": 151.20485,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eastlakes",
+			"postcode": 2018,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 18,
+			"lat": -33.93108,
+			"long": 151.21145,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pagewood",
+			"postcode": 2035,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 19,
+			"lat": -33.93894,
+			"long": 151.2136,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Daceyville",
+			"postcode": 2032,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 25,
+			"lat": -33.9289,
+			"long": 151.22527,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hillsdale",
+			"postcode": 2036,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 20,
+			"lat": -33.95297,
+			"long": 151.22753,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Banksmeadow",
+			"postcode": 2019,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -33.95607,
+			"long": 151.21365,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eastgardens",
+			"postcode": 2036,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 31,
+			"lat": -33.94502,
+			"long": 151.22653,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Louth",
+			"postcode": 2840,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 96,
+			"lat": -30.58788,
+			"long": 144.85681,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wanaaring",
+			"postcode": 2840,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 167,
+			"lat": -29.71151,
+			"long": 143.75388,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gumbalie",
+			"postcode": 2840,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 112,
+			"lat": -30.14049,
+			"long": 145.21662,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Fords Bridge",
+			"postcode": 2840,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 120,
+			"lat": -29.67848,
+			"long": 145.22456,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Enngonia",
+			"postcode": 2840,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 135,
+			"lat": -29.2745,
+			"long": 145.91309,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bourke",
+			"postcode": 2840,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 109,
+			"lat": -30.19225,
+			"long": 145.99276,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hungerford",
+			"postcode": 2840,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 123,
+			"lat": -29.20305,
+			"long": 144.61733,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gunderbooka",
+			"postcode": 2840,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 228,
+			"lat": -30.61252,
+			"long": 145.77272,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Angledool",
+			"postcode": 2834,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 148,
+			"lat": -29.1476,
+			"long": 147.92609,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Collerina",
+			"postcode": 2839,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 124,
+			"lat": -29.53603,
+			"long": 146.73061,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Narran Lake",
+			"postcode": 2839,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 118,
+			"lat": -29.81695,
+			"long": 147.31655,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Talawanta",
+			"postcode": 2839,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 125,
+			"lat": -29.57769,
+			"long": 147.0547,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Goodooga",
+			"postcode": 2838,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 135,
+			"lat": -29.31075,
+			"long": 147.44102,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Brewarrina",
+			"postcode": 2839,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 122,
+			"lat": -29.99249,
+			"long": 146.91251,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gongolgon",
+			"postcode": 2839,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 147,
+			"lat": -30.49687,
+			"long": 146.88414,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Broken Hill",
+			"postcode": 2880,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 127,
+			"lat": -32.35272,
+			"long": 141.62697,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Enfield",
+			"postcode": 2136,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 21,
+			"lat": -33.89006,
+			"long": 151.09611,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Burwood",
+			"postcode": 2134,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 33,
+			"lat": -33.87838,
+			"long": 151.10412,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Burwood Heights",
+			"postcode": 2136,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 47,
+			"lat": -33.8894,
+			"long": 151.10403,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Strathfield",
+			"postcode": 2135,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 43,
+			"lat": -33.87913,
+			"long": 151.08118,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "The Pocket",
+			"postcode": 2483,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 49,
+			"lat": -28.50326,
+			"long": 153.471,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coopers Shoot",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 113,
+			"lat": -28.69261,
+			"long": 153.56922,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tyagarah",
+			"postcode": 2481,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 36,
+			"lat": -28.60018,
+			"long": 153.55582,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "New Brighton",
+			"postcode": 2483,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 5,
+			"lat": -28.51973,
+			"long": 153.55128,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Koonyum Range",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 492,
+			"lat": -28.54188,
+			"long": 153.41082,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Palmwoods",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 176,
+			"lat": -28.5133,
+			"long": 153.40653,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Brunswick Heads",
+			"postcode": 2483,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 14,
+			"lat": -28.55754,
+			"long": 153.54453,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ocean Shores",
+			"postcode": 2483,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 31,
+			"lat": -28.50893,
+			"long": 153.53202,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "South Golden Beach",
+			"postcode": 2483,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 12,
+			"lat": -28.5004,
+			"long": 153.54669,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Middle Pocket",
+			"postcode": 2483,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 49,
+			"lat": -28.48804,
+			"long": 153.4672,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mullumbimby",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 9,
+			"lat": -28.54931,
+			"long": 153.49906,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Upper Wilsons Creek",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 493,
+			"lat": -28.52686,
+			"long": 153.38184,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wilsons Creek",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 346,
+			"lat": -28.56413,
+			"long": 153.43276,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Upper Main Arm",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 117,
+			"lat": -28.49079,
+			"long": 153.39728,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Huonbrook",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 404,
+			"lat": -28.53781,
+			"long": 153.36278,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Goonengerry",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 186,
+			"lat": -28.60459,
+			"long": 153.43207,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Byron Bay",
+			"postcode": 2481,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 13,
+			"lat": -28.6469,
+			"long": 153.60284,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Suffolk Park",
+			"postcode": 2481,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 10,
+			"lat": -28.68632,
+			"long": 153.60818,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Skinners Shoot",
+			"postcode": 2481,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 22,
+			"lat": -28.65818,
+			"long": 153.59053,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Main Arm",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 33,
+			"lat": -28.50938,
+			"long": 153.43931,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Federal",
+			"postcode": 2480,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 210,
+			"lat": -28.65916,
+			"long": 153.45262,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coorabell",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 46,
+			"lat": -28.62759,
+			"long": 153.50154,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Montecollum",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 210,
+			"lat": -28.59208,
+			"long": 153.46094,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mullumbimby Creek",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 26,
+			"lat": -28.55206,
+			"long": 153.4467,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wanganui",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 347,
+			"lat": -28.57002,
+			"long": 153.3818,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Upper Coopers Creek",
+			"postcode": 2482,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 104,
+			"lat": -28.60301,
+			"long": 153.40128,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Myocum",
+			"postcode": 2481,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 11,
+			"lat": -28.59788,
+			"long": 153.50558,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Billinudgel",
+			"postcode": 2483,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -28.50534,
+			"long": 153.51363,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yelgun",
+			"postcode": 2483,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 51,
+			"lat": -28.47992,
+			"long": 153.4948,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ewingsdale",
+			"postcode": 2481,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 37,
+			"lat": -28.63901,
+			"long": 153.55042,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bangalow",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 85,
+			"lat": -28.68063,
+			"long": 153.52403,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wooyung",
+			"postcode": 2483,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 7,
+			"lat": -28.45121,
+			"long": 153.53431,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eureka",
+			"postcode": 2480,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 110,
+			"lat": -28.68676,
+			"long": 153.43693,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Clunes",
+			"postcode": 2480,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 113,
+			"lat": -28.72557,
+			"long": 153.41144,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nashua",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 23,
+			"lat": -28.7311,
+			"long": 153.45923,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "McLeods Shoot",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 126,
+			"lat": -28.65892,
+			"long": 153.55714,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Binna Burra",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 37,
+			"lat": -28.71177,
+			"long": 153.4954,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Possum Creek",
+			"postcode": 2479,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 56,
+			"lat": -28.6712,
+			"long": 153.49287,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hayters Hill",
+			"postcode": 2481,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 105,
+			"lat": -28.6745,
+			"long": 153.58406,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Talofa",
+			"postcode": 2481,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 104,
+			"lat": -28.67336,
+			"long": 153.5561,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ophir",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 660,
+			"lat": -33.13182,
+			"long": 149.24021,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lidster",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 909,
+			"lat": -33.32192,
+			"long": 148.92622,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cargo",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 485,
+			"lat": -33.46067,
+			"long": 148.81737,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bowan Park",
+			"postcode": 2864,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 557,
+			"lat": -33.31864,
+			"long": 148.83601,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cadia",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 902,
+			"lat": -33.44302,
+			"long": 149.00978,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Waldegrave",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 906,
+			"lat": -33.43921,
+			"long": 149.04907,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "March",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 844,
+			"lat": -33.21067,
+			"long": 149.07939,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Clifton Grove",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 939,
+			"lat": -33.24096,
+			"long": 149.18515,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Summer Hill Creek",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 894,
+			"lat": -33.20626,
+			"long": 149.15508,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Four Mile Creek",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 754,
+			"lat": -33.42697,
+			"long": 148.94203,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lewis Ponds",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 728,
+			"lat": -33.28461,
+			"long": 149.27736,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lower Lewis Ponds",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 714,
+			"lat": -33.21218,
+			"long": 149.24067,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Borenore",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 730,
+			"lat": -33.23058,
+			"long": 148.95297,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nashdale",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 936,
+			"lat": -33.30633,
+			"long": 149.01005,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Canobolas",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1118,
+			"lat": -33.35685,
+			"long": 149.00882,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Belgravia",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 663,
+			"lat": -33.10567,
+			"long": 149.02988,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Springside",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1017,
+			"lat": -33.38143,
+			"long": 149.041,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Orange",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 784,
+			"lat": -33.25104,
+			"long": 149.06176,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Byng",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 866,
+			"lat": -33.34602,
+			"long": 149.24058,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Spring Terrace",
+			"postcode": 2798,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 980,
+			"lat": -33.40375,
+			"long": 149.08339,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kangaroobie",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 667,
+			"lat": -33.16904,
+			"long": 149.04759,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Emu Swamp",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 834,
+			"lat": -33.30159,
+			"long": 149.19573,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eugowra",
+			"postcode": 2806,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 301,
+			"lat": -33.41999,
+			"long": 148.35218,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yullundry",
+			"postcode": 2867,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 513,
+			"lat": -32.8594,
+			"long": 148.66962,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yeoval",
+			"postcode": 2868,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 450,
+			"lat": -32.75181,
+			"long": 148.58257,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Canowindra",
+			"postcode": 2804,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 333,
+			"lat": -33.53379,
+			"long": 148.64101,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Garra",
+			"postcode": 2866,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 487,
+			"lat": -33.1229,
+			"long": 148.75913,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Molong",
+			"postcode": 2866,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 585,
+			"lat": -33.11538,
+			"long": 148.8671,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gumble",
+			"postcode": 2865,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 527,
+			"lat": -33.08718,
+			"long": 148.65481,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Boomey",
+			"postcode": 2866,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 594,
+			"lat": -32.96794,
+			"long": 148.96012,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Obley",
+			"postcode": 2868,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 404,
+			"lat": -32.6954,
+			"long": 148.46733,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gooloogong",
+			"postcode": 2805,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 283,
+			"lat": -33.66383,
+			"long": 148.44137,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nyrang Creek",
+			"postcode": 2804,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 296,
+			"lat": -33.54527,
+			"long": 148.53312,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cudal",
+			"postcode": 2864,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 413,
+			"lat": -33.3232,
+			"long": 148.73571,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cumnock",
+			"postcode": 2867,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 519,
+			"lat": -32.92957,
+			"long": 148.66708,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Manildra",
+			"postcode": 2865,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 472,
+			"lat": -33.21351,
+			"long": 148.65261,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Boree",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 529,
+			"lat": -33.25073,
+			"long": 148.84248,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Murga",
+			"postcode": 2864,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 334,
+			"lat": -33.35802,
+			"long": 148.53618,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Moorbel",
+			"postcode": 2804,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 358,
+			"lat": -33.56319,
+			"long": 148.70315,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Amaroo",
+			"postcode": 2866,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 612,
+			"lat": -33.15948,
+			"long": 148.91946,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Toogong",
+			"postcode": 2864,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 409,
+			"lat": -33.35859,
+			"long": 148.65934,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Baldry",
+			"postcode": 2867,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 453,
+			"lat": -32.88142,
+			"long": 148.47025,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Larras Lee",
+			"postcode": 2866,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 551,
+			"lat": -32.95858,
+			"long": 148.87127,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eurimbla",
+			"postcode": 2867,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 541,
+			"lat": -32.84864,
+			"long": 148.81504,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mandagery",
+			"postcode": 2870,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 516,
+			"lat": -33.25317,
+			"long": 148.46366,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mullion Creek",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 914,
+			"lat": -33.08893,
+			"long": 149.18035,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kerrs Creek",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 815,
+			"lat": -33.05306,
+			"long": 149.10705,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Clergate",
+			"postcode": 2800,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 850,
+			"lat": -33.18723,
+			"long": 149.11571,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Camden South",
+			"postcode": 2570,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 82,
+			"lat": -34.08232,
+			"long": 150.70072,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Camden",
+			"postcode": 2570,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 82,
+			"lat": -34.05877,
+			"long": 150.69373,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Elderslie",
+			"postcode": 2570,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 86,
+			"lat": -34.0577,
+			"long": 150.71508,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Harrington Park",
+			"postcode": 2567,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 74,
+			"lat": -34.02561,
+			"long": 150.73523,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Narellan Vale",
+			"postcode": 2567,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 98,
+			"lat": -34.05177,
+			"long": 150.74372,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Narellan",
+			"postcode": 2567,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 91,
+			"lat": -34.04378,
+			"long": 150.73456,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Annan",
+			"postcode": 2567,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 115,
+			"lat": -34.06403,
+			"long": 150.76318,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Currans Hill",
+			"postcode": 2567,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 115,
+			"lat": -34.04634,
+			"long": 150.77377,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Leppington",
+			"postcode": 2179,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 110,
+			"lat": -33.97634,
+			"long": 150.79898,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gregory Hills",
+			"postcode": 2557,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 117,
+			"lat": -34.02724,
+			"long": 150.77608,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rossmore",
+			"postcode": 2557,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 85,
+			"lat": -33.93653,
+			"long": 150.77346,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ellis Lane",
+			"postcode": 2570,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 73,
+			"lat": -34.03421,
+			"long": 150.679,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cawdor",
+			"postcode": 2570,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 115,
+			"lat": -34.09589,
+			"long": 150.66638,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kirkham",
+			"postcode": 2570,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 82,
+			"lat": -34.03394,
+			"long": 150.70955,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Catherine Field",
+			"postcode": 2557,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 79,
+			"lat": -33.98618,
+			"long": 150.76993,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bringelly",
+			"postcode": 2556,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 88,
+			"lat": -33.94576,
+			"long": 150.72523,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cobbitty",
+			"postcode": 2570,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 66,
+			"lat": -33.99798,
+			"long": 150.67997,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Smeaton Grange",
+			"postcode": 2567,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 83,
+			"lat": -34.03721,
+			"long": 150.75725,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Grasmere",
+			"postcode": 2570,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 88,
+			"lat": -34.05634,
+			"long": 150.6729,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kearns",
+			"postcode": 2558,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 87,
+			"lat": -34.01979,
+			"long": 150.80135,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Raby",
+			"postcode": 2566,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 67,
+			"lat": -34.02019,
+			"long": 150.81645,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eschol Park",
+			"postcode": 2558,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 86,
+			"lat": -34.03422,
+			"long": 150.80399,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eagle Vale",
+			"postcode": 2558,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 89,
+			"lat": -34.03797,
+			"long": 150.81128,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "St Andrews",
+			"postcode": 2566,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 47,
+			"lat": -34.02451,
+			"long": 150.83058,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ingleburn",
+			"postcode": 2565,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 41,
+			"lat": -34.0051,
+			"long": 150.8581,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bow Bowing",
+			"postcode": 2566,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 39,
+			"lat": -34.01729,
+			"long": 150.84136,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Denham Court",
+			"postcode": 2565,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 98,
+			"lat": -33.98157,
+			"long": 150.8294,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Minto",
+			"postcode": 2566,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 71,
+			"lat": -34.03164,
+			"long": 150.84989,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Macquarie Fields",
+			"postcode": 2564,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 35,
+			"lat": -33.99111,
+			"long": 150.8917,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glenfield",
+			"postcode": 2167,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 29,
+			"lat": -33.97099,
+			"long": 150.89301,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Blairmount",
+			"postcode": 2559,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 86,
+			"lat": -34.05088,
+			"long": 150.79444,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Claymore",
+			"postcode": 2559,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 82,
+			"lat": -34.04717,
+			"long": 150.81206,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kentlyn",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 113,
+			"lat": -34.06199,
+			"long": 150.86946,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Macquarie Links",
+			"postcode": 2565,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 45,
+			"lat": -33.97953,
+			"long": 150.87193,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Minto Heights",
+			"postcode": 2566,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 112,
+			"lat": -34.03359,
+			"long": 150.87512,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Varroville",
+			"postcode": 2566,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 83,
+			"lat": -34.00405,
+			"long": 150.81008,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Long Point",
+			"postcode": 2564,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 72,
+			"lat": -34.0115,
+			"long": 150.89643,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Campbelltown",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 65,
+			"lat": -34.06338,
+			"long": 150.80766,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bradbury",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 126,
+			"lat": -34.08405,
+			"long": 150.81805,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wedderburn",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 235,
+			"lat": -34.14312,
+			"long": 150.8241,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "St Helens Park",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 138,
+			"lat": -34.1056,
+			"long": 150.81488,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Leumeah",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 81,
+			"lat": -34.05375,
+			"long": 150.83957,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ambarvale",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 118,
+			"lat": -34.089,
+			"long": 150.79408,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glen Alpine",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 121,
+			"lat": -34.08767,
+			"long": 150.7719,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rosemeadow",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 149,
+			"lat": -34.10624,
+			"long": 150.79181,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Woodbine",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 65,
+			"lat": -34.04484,
+			"long": 150.82045,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gilead",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 148,
+			"lat": -34.12934,
+			"long": 150.7799,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Holsworthy",
+			"postcode": 2173,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 156,
+			"lat": -34.06831,
+			"long": 150.9054,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Woronora Dam",
+			"postcode": 2508,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 263,
+			"lat": -34.15478,
+			"long": 150.93921,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ruse",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 115,
+			"lat": -34.06927,
+			"long": 150.83989,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Airds",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 142,
+			"lat": -34.08593,
+			"long": 150.83302,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Blair Athol",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 93,
+			"lat": -34.06196,
+			"long": 150.80158,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Menangle Park",
+			"postcode": 2563,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 95,
+			"lat": -34.10002,
+			"long": 150.75682,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Englorie Park",
+			"postcode": 2560,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 113,
+			"lat": -34.08048,
+			"long": 150.79659,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Concord West",
+			"postcode": 2138,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 16,
+			"lat": -33.8435,
+			"long": 151.092,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "North Strathfield",
+			"postcode": 2137,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 23,
+			"lat": -33.85783,
+			"long": 151.08877,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Concord",
+			"postcode": 2137,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 6,
+			"lat": -33.85608,
+			"long": 151.10677,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cabarita",
+			"postcode": 2137,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 10,
+			"lat": -33.84744,
+			"long": 151.11635,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rhodes",
+			"postcode": 2138,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 7,
+			"lat": -33.83004,
+			"long": 151.0887,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Breakfast Point",
+			"postcode": 2137,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 16,
+			"lat": -33.84282,
+			"long": 151.11092,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Liberty Grove",
+			"postcode": 2138,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 8,
+			"lat": -33.84081,
+			"long": 151.08387,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mortlake",
+			"postcode": 2137,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 14,
+			"lat": -33.84052,
+			"long": 151.1065,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Five Dock",
+			"postcode": 2046,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 16,
+			"lat": -33.86665,
+			"long": 151.12685,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Abbotsford",
+			"postcode": 2046,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 23,
+			"lat": -33.85052,
+			"long": 151.12987,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Chiswick",
+			"postcode": 2046,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 15,
+			"lat": -33.84987,
+			"long": 151.13772,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Russell Lea",
+			"postcode": 2046,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 20,
+			"lat": -33.85841,
+			"long": 151.14202,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rodd Point",
+			"postcode": 2046,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 10,
+			"lat": -33.86584,
+			"long": 151.14375,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Drummoyne",
+			"postcode": 2047,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 31,
+			"lat": -33.85205,
+			"long": 151.15424,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Canada Bay",
+			"postcode": 2046,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 9,
+			"lat": -33.86462,
+			"long": 151.11506,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wareemba",
+			"postcode": 2046,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 21,
+			"lat": -33.85759,
+			"long": 151.13219,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Riverwood",
+			"postcode": 2210,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 15,
+			"lat": -33.9451,
+			"long": 151.05302,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Roselands",
+			"postcode": 2196,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 54,
+			"lat": -33.93329,
+			"long": 151.07526,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Belmore",
+			"postcode": 2192,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 32,
+			"lat": -33.91942,
+			"long": 151.08774,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Belfield",
+			"postcode": 2191,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 22,
+			"lat": -33.90421,
+			"long": 151.08616,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kingsgrove",
+			"postcode": 2208,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 19,
+			"lat": -33.93971,
+			"long": 151.09956,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Campsie",
+			"postcode": 2194,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 35,
+			"lat": -33.91457,
+			"long": 151.10339,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Clemton Park",
+			"postcode": 2206,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -33.92577,
+			"long": 151.10309,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Earlwood",
+			"postcode": 2206,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 33,
+			"lat": -33.92492,
+			"long": 151.13127,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Canterbury",
+			"postcode": 2193,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 6,
+			"lat": -33.913,
+			"long": 151.1171,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Beverly Hills",
+			"postcode": 2209,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 49,
+			"lat": -33.94831,
+			"long": 151.07815,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Narwee",
+			"postcode": 2209,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 42,
+			"lat": -33.9472,
+			"long": 151.06843,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wiley Park",
+			"postcode": 2195,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 39,
+			"lat": -33.9234,
+			"long": 151.06765,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lakemba",
+			"postcode": 2195,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 33,
+			"lat": -33.91825,
+			"long": 151.07547,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Goolgowi",
+			"postcode": 2652,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 115,
+			"lat": -33.94636,
+			"long": 145.72934,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Melbergen",
+			"postcode": 2669,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 160,
+			"lat": -33.74595,
+			"long": 146.00891,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Erigolia",
+			"postcode": 2669,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 174,
+			"lat": -33.91933,
+			"long": 146.3892,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Merriwagga",
+			"postcode": 2652,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 106,
+			"lat": -33.81688,
+			"long": 145.67999,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Carrathool",
+			"postcode": 2711,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 112,
+			"lat": -34.45773,
+			"long": 145.45064,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Willbriggie",
+			"postcode": 2680,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 123,
+			"lat": -34.46214,
+			"long": 145.99583,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yenda",
+			"postcode": 2681,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 133,
+			"lat": -34.22789,
+			"long": 146.21839,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Binya",
+			"postcode": 2665,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 180,
+			"lat": -34.15384,
+			"long": 146.31382,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hillston",
+			"postcode": 2675,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 114,
+			"lat": -33.44347,
+			"long": 145.39759,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Roto",
+			"postcode": 2675,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 149,
+			"lat": -32.96511,
+			"long": 145.27693,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wallanthery",
+			"postcode": 2675,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 141,
+			"lat": -33.31469,
+			"long": 145.87065,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Boorga",
+			"postcode": 2652,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 140,
+			"lat": -34.02099,
+			"long": 146.01821,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tabbita",
+			"postcode": 2652,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 116,
+			"lat": -34.09674,
+			"long": 145.83302,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Benerembah",
+			"postcode": 2680,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 117,
+			"lat": -34.39946,
+			"long": 145.82854,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Warrawidgee",
+			"postcode": 2680,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 111,
+			"lat": -34.30721,
+			"long": 145.73982,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Monia Gap",
+			"postcode": 2675,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 238,
+			"lat": -33.58536,
+			"long": 145.9726,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yorklea",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -28.93029,
+			"long": 153.06351,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Naughtons Gap",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 140,
+			"lat": -28.80202,
+			"long": 153.10794,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tomki",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 15,
+			"lat": -28.86457,
+			"long": 153.1425,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coraki",
+			"postcode": 2471,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 8,
+			"lat": -28.98707,
+			"long": 153.27084,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Evans Head",
+			"postcode": 2473,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 8,
+			"lat": -29.11426,
+			"long": 153.42336,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "New Italy",
+			"postcode": 2472,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 24,
+			"lat": -29.139,
+			"long": 153.29872,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Stratheden",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 49,
+			"lat": -28.75801,
+			"long": 152.94516,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Fairy Hill",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 43,
+			"lat": -28.76136,
+			"long": 152.98547,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Backmede",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 49,
+			"lat": -28.76143,
+			"long": 153.02409,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "North Casino",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 55,
+			"lat": -28.80756,
+			"long": 153.06684,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bentley",
+			"postcode": 2480,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 43,
+			"lat": -28.75617,
+			"long": 153.09521,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Spring Grove",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 94,
+			"lat": -28.82619,
+			"long": 153.13243,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Irvington",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 18,
+			"lat": -28.86557,
+			"long": 153.09845,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "McKees Hill",
+			"postcode": 2480,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 34,
+			"lat": -28.87121,
+			"long": 153.18313,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Greenridge",
+			"postcode": 2471,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 15,
+			"lat": -28.89939,
+			"long": 153.11726,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dobies Bight",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 53,
+			"lat": -28.79901,
+			"long": 152.94078,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Woodview",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 53,
+			"lat": -28.84464,
+			"long": 152.93702,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Piora",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 132,
+			"lat": -28.86186,
+			"long": 152.8847,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hogarth Range",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 314,
+			"lat": -28.91392,
+			"long": 152.81907,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Upper Mongogarie",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 99,
+			"lat": -28.96308,
+			"long": 152.80753,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wyan",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 81,
+			"lat": -29.06088,
+			"long": 152.86711,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coombell",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 53,
+			"lat": -29.02202,
+			"long": 152.9468,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mongogarie",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 91,
+			"lat": -28.94461,
+			"long": 152.90371,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Busbys Flat",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 233,
+			"lat": -29.07417,
+			"long": 152.77919,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Six Mile Swamp",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 121,
+			"lat": -29.18778,
+			"long": 152.85871,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Marsh",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 154,
+			"lat": -29.27044,
+			"long": 152.85078,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kippenduff",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 151,
+			"lat": -29.1643,
+			"long": 152.8091,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Myrtle Creek",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 46,
+			"lat": -29.16806,
+			"long": 153.00445,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Camira",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 57,
+			"lat": -29.21971,
+			"long": 152.9336,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Clearfield",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 68,
+			"lat": -29.15342,
+			"long": 152.9161,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Whiporie",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 54,
+			"lat": -29.2733,
+			"long": 153.00186,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gibberagee",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 86,
+			"lat": -29.28762,
+			"long": 153.10115,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Shannon Brook",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 41,
+			"lat": -28.90291,
+			"long": 152.96567,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rappville",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 87,
+			"lat": -29.06696,
+			"long": 152.95381,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ellangowan",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 41,
+			"lat": -29.0329,
+			"long": 153.09334,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Leeville",
+			"postcode": 2470,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 56,
+			"lat": -28.9726,
+			"long": 152.99052,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "West Bungawalbin",
+			"postcode": 2471,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 17,
+			"lat": -29.12896,
+			"long": 153.12311,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bora Ridge",
+			"postcode": 2471,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 12,
+			"lat": -29.07919,
+			"long": 153.19411,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tatham",
+			"postcode": 2471,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 11,
+			"lat": -28.94068,
+			"long": 153.16203,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bungawalbin",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 14,
+			"lat": -29.0975,
+			"long": 153.22064,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Esk",
+			"postcode": 2472,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 7,
+			"lat": -29.25558,
+			"long": 153.33178,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Codrington",
+			"postcode": 2471,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 6,
+			"lat": -28.9542,
+			"long": 153.23674,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "West Coraki",
+			"postcode": 2471,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 11,
+			"lat": -29.00146,
+			"long": 153.2153,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "East Coraki",
+			"postcode": 2471,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1,
+			"lat": -29.0129,
+			"long": 153.31092,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Swan Bay",
+			"postcode": 2471,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 2,
+			"lat": -29.07553,
+			"long": 153.29462,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Woodburn",
+			"postcode": 2472,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1,
+			"lat": -29.09632,
+			"long": 153.35589,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Doonbah",
+			"postcode": 2473,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 9,
+			"lat": -29.08411,
+			"long": 153.37511,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rileys Hill",
+			"postcode": 2472,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 12,
+			"lat": -29.03128,
+			"long": 153.39317,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Broadwater",
+			"postcode": 2472,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 30,
+			"lat": -29.03581,
+			"long": 153.43522,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tabbimoble",
+			"postcode": 2472,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 31,
+			"lat": -29.20673,
+			"long": 153.27766,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "The Gap",
+			"postcode": 2472,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 11,
+			"lat": -29.18207,
+			"long": 153.40831,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Menindee",
+			"postcode": 2879,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 65,
+			"lat": -32.36855,
+			"long": 142.69116,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wilcannia",
+			"postcode": 2836,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 83,
+			"lat": -31.20982,
+			"long": 143.61966,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tilpa",
+			"postcode": 2840,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 89,
+			"lat": -30.99286,
+			"long": 144.40759,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Weston",
+			"postcode": 2326,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 21,
+			"lat": -32.81035,
+			"long": 151.45624,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Loxford",
+			"postcode": 2326,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 11,
+			"lat": -32.79421,
+			"long": 151.48844,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kurri Kurri",
+			"postcode": 2327,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 33,
+			"lat": -32.81462,
+			"long": 151.47978,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bellbird",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 97,
+			"lat": -32.85495,
+			"long": 151.31703,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Abermain",
+			"postcode": 2326,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 42,
+			"lat": -32.82298,
+			"long": 151.43614,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Paxton",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 135,
+			"lat": -32.90426,
+			"long": 151.28608,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kitchener",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 106,
+			"lat": -32.88207,
+			"long": 151.36699,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Abernethy",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 93,
+			"lat": -32.88591,
+			"long": 151.40181,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cessnock",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 93,
+			"lat": -32.83348,
+			"long": 151.36699,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pelton",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 162,
+			"lat": -32.8805,
+			"long": 151.31579,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ellalong",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 117,
+			"lat": -32.92948,
+			"long": 151.31132,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount View",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 238,
+			"lat": -32.8529,
+			"long": 151.26355,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Greta Main",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 149,
+			"lat": -32.88848,
+			"long": 151.28436,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sawyers Gully",
+			"postcode": 2326,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 60,
+			"lat": -32.77678,
+			"long": 151.45062,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lovedale",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 54,
+			"lat": -32.75281,
+			"long": 151.3619,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Neath",
+			"postcode": 2326,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 51,
+			"lat": -32.82154,
+			"long": 151.41539,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kearsley",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 56,
+			"lat": -32.8504,
+			"long": 151.40027,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nulkaba",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 76,
+			"lat": -32.80439,
+			"long": 151.35882,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cliftleigh",
+			"postcode": 2321,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 19,
+			"lat": -32.78839,
+			"long": 151.51795,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Fernances Crossing",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 224,
+			"lat": -33.06821,
+			"long": 151.11262,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Keinbah",
+			"postcode": 2320,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 80,
+			"lat": -32.75621,
+			"long": 151.40986,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Black Hill",
+			"postcode": 2322,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -32.81921,
+			"long": 151.61571,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Paynes Crossing",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 233,
+			"lat": -32.91233,
+			"long": 151.04786,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wollombi",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 184,
+			"lat": -32.96169,
+			"long": 151.15414,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Narone Creek",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 161,
+			"lat": -32.93644,
+			"long": 151.16308,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Murrays Run",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 289,
+			"lat": -33.07684,
+			"long": 151.17987,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Watagan",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 219,
+			"lat": -33.0105,
+			"long": 151.20777,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "North Rothbury",
+			"postcode": 2335,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 59,
+			"lat": -32.69332,
+			"long": 151.34673,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pokolbin",
+			"postcode": 2320,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 104,
+			"lat": -32.75353,
+			"long": 151.27834,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Greta",
+			"postcode": 2334,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 58,
+			"lat": -32.69162,
+			"long": 151.3859,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Aberdare",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 89,
+			"lat": -32.84063,
+			"long": 151.38129,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "East Branxton",
+			"postcode": 2335,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 46,
+			"lat": -32.65641,
+			"long": 151.36458,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Branxton",
+			"postcode": 2335,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 52,
+			"lat": -32.64158,
+			"long": 151.35649,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bellbird Heights",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 114,
+			"lat": -32.8488,
+			"long": 151.33092,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Elrington",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 64,
+			"lat": -32.86458,
+			"long": 151.42921,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mulbring",
+			"postcode": 2323,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 46,
+			"lat": -32.89663,
+			"long": 151.48544,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Stockrington",
+			"postcode": 2322,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 139,
+			"lat": -32.86344,
+			"long": 151.57646,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yengo National Park",
+			"postcode": 2330,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 107,
+			"lat": -33.01902,
+			"long": 150.91338,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Olney",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 367,
+			"lat": -33.03749,
+			"long": 151.32008,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Buchanan",
+			"postcode": 2323,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 30,
+			"lat": -32.82189,
+			"long": 151.53112,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cedar Creek",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 355,
+			"lat": -32.8355,
+			"long": 151.16861,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mount Vincent",
+			"postcode": 2323,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 46,
+			"lat": -32.93341,
+			"long": 151.47865,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bucketty",
+			"postcode": 2250,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 227,
+			"lat": -33.10955,
+			"long": 151.15408,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bishops Bridge",
+			"postcode": 2326,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 20,
+			"lat": -32.74516,
+			"long": 151.46674,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Richmond Vale",
+			"postcode": 2323,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -32.864,
+			"long": 151.49818,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pelaw Main",
+			"postcode": 2327,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 37,
+			"lat": -32.83755,
+			"long": 151.48265,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Millfield",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 110,
+			"lat": -32.89371,
+			"long": 151.25182,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Heddon Greta",
+			"postcode": 2321,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 28,
+			"lat": -32.80705,
+			"long": 151.50441,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Stanford Merthyr",
+			"postcode": 2327,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 37,
+			"lat": -32.82438,
+			"long": 151.49319,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Congewai",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 525,
+			"lat": -32.96974,
+			"long": 151.30144,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dairy Arm",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 284,
+			"lat": -33.04921,
+			"long": 151.18523,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Laguna",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 237,
+			"lat": -33.04123,
+			"long": 151.01241,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Corrabare",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 351,
+			"lat": -32.94909,
+			"long": 151.21988,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Brunkerville",
+			"postcode": 2323,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 112,
+			"lat": -32.9533,
+			"long": 151.48714,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Quorrobolong",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 165,
+			"lat": -32.93446,
+			"long": 151.38123,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Buttai",
+			"postcode": 2323,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 42,
+			"lat": -32.83168,
+			"long": 151.56088,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sweetmans Creek",
+			"postcode": 2325,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 130,
+			"lat": -32.89103,
+			"long": 151.1832,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Allandale",
+			"postcode": 2320,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 96,
+			"lat": -32.72469,
+			"long": 151.41344,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "The Sandon",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 9,
+			"lat": -29.66652,
+			"long": 153.29733,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Diggers Camp",
+			"postcode": 2462,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 35,
+			"lat": -29.8122,
+			"long": 153.27338,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Minnie Water",
+			"postcode": 2462,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 7,
+			"lat": -29.74535,
+			"long": 153.27049,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Barcoongere",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 54,
+			"lat": -29.8893,
+			"long": 153.2608,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sandy Crossing",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 7,
+			"lat": -29.76446,
+			"long": 153.09399,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sandon",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 30,
+			"lat": -29.68673,
+			"long": 153.31233,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pillar Valley",
+			"postcode": 2462,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 17,
+			"lat": -29.6952,
+			"long": 153.15625,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bookram",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 27,
+			"lat": -29.71867,
+			"long": 153.24471,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wooli",
+			"postcode": 2462,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 30,
+			"lat": -29.82987,
+			"long": 153.2399,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coldstream",
+			"postcode": 2462,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 2,
+			"lat": -29.60028,
+			"long": 153.11024,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gilletts Ridge",
+			"postcode": 2462,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 12,
+			"lat": -29.63508,
+			"long": 153.10881,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cowper",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1,
+			"lat": -29.57956,
+			"long": 153.08927,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glenugie",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 82,
+			"lat": -29.81103,
+			"long": 153.03825,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Halfway Creek",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 105,
+			"lat": -29.93822,
+			"long": 153.10077,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tucabia",
+			"postcode": 2462,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 17,
+			"lat": -29.6573,
+			"long": 153.12708,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ulmarra",
+			"postcode": 2462,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 2,
+			"lat": -29.63884,
+			"long": 153.04869,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Calliope",
+			"postcode": 2462,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -29.61419,
+			"long": 153.07441,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Maclean",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 69,
+			"lat": -29.45104,
+			"long": 153.21732,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Freeburn Island",
+			"postcode": 2464,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 7,
+			"lat": -29.40154,
+			"long": 153.33215,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Brooms Head",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 42,
+			"lat": -29.61591,
+			"long": 153.2891,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yamba",
+			"postcode": 2464,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 0,
+			"lat": -29.43373,
+			"long": 153.34213,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Yuraygir",
+			"postcode": 2464,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 34,
+			"lat": -29.53089,
+			"long": 153.32996,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wooloweyah",
+			"postcode": 2464,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 0,
+			"lat": -29.48646,
+			"long": 153.31611,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Iluka",
+			"postcode": 2466,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 14,
+			"lat": -29.39868,
+			"long": 153.35727,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Micalo Island",
+			"postcode": 2464,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 0,
+			"lat": -29.45091,
+			"long": 153.31254,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lawrence",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 11,
+			"lat": -29.44243,
+			"long": 153.08484,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tullymorgan",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 10,
+			"lat": -29.38172,
+			"long": 153.10707,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Jacky Bulbin Flat",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 193,
+			"lat": -29.28112,
+			"long": 153.19346,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mororo",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 175,
+			"lat": -29.34539,
+			"long": 153.19517,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Warregah Island",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 0,
+			"lat": -29.38755,
+			"long": 153.23017,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Palmers Channel",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1,
+			"lat": -29.45952,
+			"long": 153.27936,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Palmers Island",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 2,
+			"lat": -29.432,
+			"long": 153.2962,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Woody Head",
+			"postcode": 2466,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 2,
+			"lat": -29.36441,
+			"long": 153.36788,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Woombah",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 15,
+			"lat": -29.31139,
+			"long": 153.28181,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Goodwood Island",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 0,
+			"lat": -29.38134,
+			"long": 153.30719,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Woodford Island",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 2,
+			"lat": -29.50941,
+			"long": 153.13488,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ilarwill",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 168,
+			"lat": -29.48571,
+			"long": 153.17514,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ashby Island",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1,
+			"lat": -29.42357,
+			"long": 153.2041,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "The Freshwater",
+			"postcode": 2466,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 7,
+			"lat": -29.34076,
+			"long": 153.33538,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Brushgrove",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -29.56005,
+			"long": 153.08705,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Townsend",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 11,
+			"lat": -29.46315,
+			"long": 153.22039,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "South Arm",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 76,
+			"lat": -29.51072,
+			"long": 153.1691,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tyndale",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 71,
+			"lat": -29.55991,
+			"long": 153.15949,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Chatsworth",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 2,
+			"lat": -29.38934,
+			"long": 153.24787,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Harwood",
+			"postcode": 2465,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -29.41289,
+			"long": 153.24136,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ashby Heights",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 54,
+			"lat": -29.38688,
+			"long": 153.1793,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Angourie",
+			"postcode": 2464,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 19,
+			"lat": -29.4688,
+			"long": 153.35585,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gulmarrad",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 35,
+			"lat": -29.50024,
+			"long": 153.224,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ashby",
+			"postcode": 2463,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 111,
+			"lat": -29.44047,
+			"long": 153.18439,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Swan Creek",
+			"postcode": 2462,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -29.66673,
+			"long": 153.00339,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Clarenza",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 24,
+			"lat": -29.70042,
+			"long": 153.00356,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Braunstone",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 39,
+			"lat": -29.81009,
+			"long": 152.94265,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coutts Crossing",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 69,
+			"lat": -29.85687,
+			"long": 152.89291,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Elland",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 79,
+			"lat": -29.78072,
+			"long": 152.89999,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ramornie",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 152,
+			"lat": -29.65703,
+			"long": 152.69224,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Eatonsville",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 21,
+			"lat": -29.6395,
+			"long": 152.82913,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Waterview",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 8,
+			"lat": -29.6825,
+			"long": 152.90484,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Seelands",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 7,
+			"lat": -29.62269,
+			"long": 152.89484,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Waterview Heights",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 63,
+			"lat": -29.68998,
+			"long": 152.84875,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Rushforth",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 52,
+			"lat": -29.74879,
+			"long": 152.85967,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Grafton",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 6,
+			"lat": -29.67476,
+			"long": 152.92977,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "South Grafton",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 37,
+			"lat": -29.72693,
+			"long": 152.93474,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Carrs Island",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -29.67304,
+			"long": 152.91164,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Junction Hill",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 13,
+			"lat": -29.63666,
+			"long": 152.93103,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Great Marlow",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 5,
+			"lat": -29.64973,
+			"long": 152.97267,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Crowther Island",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -29.62704,
+			"long": 152.9188,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Alumy Creek",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -29.64246,
+			"long": 152.9576,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Carrs Creek",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -29.65574,
+			"long": 152.92225,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Southgate",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 20,
+			"lat": -29.5995,
+			"long": 153.00524,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Carrs Peninsula",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 5,
+			"lat": -29.65115,
+			"long": 152.90581,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Trenayr",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 4,
+			"lat": -29.61397,
+			"long": 152.95472,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bom Bom",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 90,
+			"lat": -29.75957,
+			"long": 152.9659,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lanitza",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 67,
+			"lat": -29.87518,
+			"long": 152.9682,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Sherwood",
+			"postcode": 2450,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 135,
+			"lat": -30.03664,
+			"long": 153.04625,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Glenreagh",
+			"postcode": 2450,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 156,
+			"lat": -30.08784,
+			"long": 152.95599,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kungala",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 67,
+			"lat": -29.95277,
+			"long": 153.03333,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kremnos",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 95,
+			"lat": -29.97508,
+			"long": 152.94911,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wells Crossing",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 75,
+			"lat": -29.8961,
+			"long": 153.03336,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Marengo",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1283,
+			"lat": -30.14456,
+			"long": 152.41283,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Cangai",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 104,
+			"lat": -29.47525,
+			"long": 152.45002,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Jackadgery",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 254,
+			"lat": -29.61397,
+			"long": 152.53492,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coombadjha",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 86,
+			"lat": -29.38598,
+			"long": 152.47847,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Billys Creek",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 708,
+			"lat": -30.16629,
+			"long": 152.57405,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lilydale",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 27,
+			"lat": -29.54447,
+			"long": 152.66142,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Chaelundi",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 877,
+			"lat": -29.98343,
+			"long": 152.42977,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Heifer Station",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 378,
+			"lat": -29.44123,
+			"long": 152.58703,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Dundurrabin",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1048,
+			"lat": -30.14048,
+			"long": 152.51949,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Buccarumbi",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 293,
+			"lat": -29.83387,
+			"long": 152.60844,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Chambigne",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 67,
+			"lat": -29.77012,
+			"long": 152.72187,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Clouds Creek",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 662,
+			"lat": -30.09077,
+			"long": 152.65204,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Nymboida",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 472,
+			"lat": -29.95492,
+			"long": 152.66498,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Wild Cattle Creek",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 466,
+			"lat": -30.1312,
+			"long": 152.74593,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Moonpar",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 824,
+			"lat": -30.22208,
+			"long": 152.64243,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Levenstrath",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 62,
+			"lat": -29.82874,
+			"long": 152.93292,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Hernani",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1251,
+			"lat": -30.3078,
+			"long": 152.40616,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Towallum",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 278,
+			"lat": -30.07711,
+			"long": 152.83141,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Tyringham",
+			"postcode": 2453,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 1003,
+			"lat": -30.24793,
+			"long": 152.49968,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Blaxlands Creek",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 233,
+			"lat": -29.89015,
+			"long": 152.79964,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Newton Boyd",
+			"postcode": 2370,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 418,
+			"lat": -29.7004,
+			"long": 152.34086,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Kangaroo Creek",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 328,
+			"lat": -29.97568,
+			"long": 152.85282,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Shannondale",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 60,
+			"lat": -29.79746,
+			"long": 152.83599,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Upper Fine Flower",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 113,
+			"lat": -29.27652,
+			"long": 152.73001,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Stockyard Creek",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 98,
+			"lat": -29.51509,
+			"long": 152.80964,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lower Southgate",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 3,
+			"lat": -29.53783,
+			"long": 153.05415,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coaldale",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 115,
+			"lat": -29.39466,
+			"long": 152.80533,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Gurranang",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 45,
+			"lat": -29.45281,
+			"long": 152.97931,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Ewingar",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 360,
+			"lat": -29.09105,
+			"long": 152.50753,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Bulldog",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 305,
+			"lat": -29.0325,
+			"long": 152.49894,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Mookima Wybra",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 154,
+			"lat": -29.00683,
+			"long": 152.53343,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Louisa Creek",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 134,
+			"lat": -29.01778,
+			"long": 152.61222,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Pikapene",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 135,
+			"lat": -29.04791,
+			"long": 152.65731,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Lionsville",
+			"postcode": 2460,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 231,
+			"lat": -29.18412,
+			"long": 152.50662,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Alice",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 111,
+			"lat": -29.05472,
+			"long": 152.58904,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Keybarbin",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 186,
+			"lat": -29.10556,
+			"long": 152.61779,
+			"timezone": "Australia/Sydney"
+		},
+		{
+			"suburb": "Coongbar",
+			"postcode": 2469,
+			"state": "NSW",
+			"state_fullname": "New South Wales",
+			"elevation": 167,
+			"lat": -29.10812,
+			"long": 152.69708,
+			"timezone": "Australia/Sydney"
+		}
+	]
+}


### PR DESCRIPTION
- Setup API functionality to successfully take in a suburb parameter entered by user and retrieve it's correct data
- Currently using a default location regardless of user input for testing purposes, correct parameter implementation on the line above it, commented out